### PR TITLE
Proposal: accept `into` option

### DIFF
--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -1,10 +1,17 @@
 defmodule SqlitexTest do
   use ExUnit.Case
 
-  test "a basic query returns maps" do
+  test "a basic query returns a list of keyword lists" do
     {:ok, db} = Sqlitex.open('test/fixtures/golfscores.sqlite3')
     [row] = db |> Sqlitex.query("SELECT * FROM players ORDER BY id LIMIT 1")
     assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]
+    Sqlitex.close(db)
+  end
+
+  test "a basic query returns a list of maps when into: %{} is given" do
+    {:ok, db} = Sqlitex.open('test/fixtures/golfscores.sqlite3')
+    [row] = db |> Sqlitex.query("SELECT * FROM players ORDER BY id LIMIT 1", into: %{})
+    assert row == %{id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil}
     Sqlitex.close(db)
   end
 


### PR DESCRIPTION
Hi, considering #2 I added third argument `opts` to `Sqlitex.query`.
The point is that users can specify the data structure of return values.

This change allows us to do:

```elixir
Sqlite.query(db, sql)            #=> [[id: 1, name: ...], [id: 2, name: ...]]
Sqlite.query(db, sql, into: [])  #=> [[id: 1, name: ...], [id: 2, name: ...]] (same as above)
Sqlite.query(db, sql, into: %{}) #=> [%{id: 1, name: ...}, %{id: 2, name: ...}]
```

The test is also added.
Thank you.