### PR TITLE
GenServer improvements

### DIFF
--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -16,8 +16,13 @@ defmodule Sqlitex.Server do
     {:reply, rows, db}
   end
 
-  def handle_call(:stop, _from, db) do
-    {:stop, :normal, Sqlitex.close(db), db}
+  def handle_cast(:stop, db) do
+    {:stop, :normal, db}
+  end
+
+  def terminate(_reason, db) do
+    Sqlitex.close(db)
+    :ok
   end
 
   ## Public API
@@ -31,6 +36,6 @@ defmodule Sqlitex.Server do
   end
 
   def stop(pid) do
-    GenServer.call(pid, :stop)
+    GenServer.cast(pid, :stop)
   end
 end

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -2,8 +2,16 @@ defmodule Sqlitex.Server do
   use GenServer
 
   def start_link(db_path) do
-    {:ok, db} = Sqlitex.open(db_path)
-    GenServer.start_link(__MODULE__, db)
+    GenServer.start_link(__MODULE__, db_path)
+  end
+
+  ## GenServer callbacks
+
+  def init(db_path) do
+    case Sqlitex.open(db_path) do
+      {:ok, db} -> {:ok, db}
+      {:error, reason} -> {:stop, reason}
+    end
   end
 
   def handle_call({:exec, sql}, _from, db) do

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -11,6 +11,13 @@ defmodule SqlitexTest do
     {:ok, golf_db: TestDatabase.init(db)}
   end
 
+  test "server basic query" do
+    {:ok, conn} = Sqlitex.Server.start_link(@shared_cache)
+    [row] = Sqlitex.Server.query(conn, "SELECT * FROM players ORDER BY id LIMIT 1")
+    assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]
+    Sqlitex.Server.stop(conn)
+  end
+
   test "a basic query returns a list of keyword lists", context do
     [row] = context[:golf_db] |> Sqlitex.query("SELECT * FROM players ORDER BY id LIMIT 1")
     assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]


### PR DESCRIPTION
These changes:

1. Move `Sqlitex.close/1` into `Sqlitex.Server.terminate/2` so that the database connection gets closed regardless of the way the GenServer is terminated.
2. Move `Sqlitex.open/1` into `Sqlitex.Server.init/1` to provide some symmetry to (1) above.
3. Convert `Sqlitex.Server.stop/1` to a cast since we no longer expect a return value from close.

I made the first change because the Ecto tests were killing the GenServer process, and since I wasn't able to call stop() explicitly, the SQLite connection was never closed.  The other changes just seemed like a natural consequence of the first.