### PR TITLE
Adds GenServer Options to Sqlitex.Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Elixir wrapper around [https://github.com/mmzeeman/esqlite](esqlite). The mai
 Usage
 =====
 
-The simples way to use sqlitex is just to open a database and run a query
+The simple way to use sqlitex is just to open a database and run a query
 
 ```elixir
 Sqlitex.with_db('test/fixtures/golfscores.sqlite3', fn(db) ->
@@ -29,13 +29,14 @@ children = [
       # Start the endpoint when the application starts
       worker(Golf.Endpoint, []),
 
-      worker(Sqlitex.Server, ['/Users/hqmq/code/golfscore-phoenix/db/golf.sqlite3'])
+      worker(Sqlitex.Server, ['golf.sqlite3', [name: Sqlitex.Server]])
     ]
 ```
 
 Now that the GenServer is running you can make queries via
 ```elixir
-Sqlitex.Server.query("SELECT g.id, g.course_id, g.played_at, c.name AS course
+Sqlitex.Server.query(Sqlitex.Server,
+                     "SELECT g.id, g.course_id, g.played_at, c.name AS course
                       FROM games AS g
                       INNER JOIN courses AS c ON g.course_id = c.id
                       ORDER BY g.played_at DESC LIMIT 10")
@@ -49,6 +50,6 @@ I'm using [Benchfella](https://github.com/alco/benchfella) to keep track of our 
 Plans
 =====
 
-This package currently only supports really basic reads. I am building this package as an attempt to learn more about Elixir and I'll be adding features only as I need them.
+I am building this package as an attempt to learn more about Elixir and I'll be adding features only as I need them.
 
 I would love to get any feedback I can on how other people might want to use SQlite with Elixir.

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -1,8 +1,8 @@
 defmodule Sqlitex.Server do
   use GenServer
 
-  def start_link(db_path) do
-    GenServer.start_link(__MODULE__, db_path)
+  def start_link(db_path, opts \\ []) do
+    GenServer.start_link(__MODULE__, db_path, opts)
   end
 
   ## GenServer callbacks

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -18,6 +18,13 @@ defmodule SqlitexTest do
     Sqlitex.Server.stop(conn)
   end
 
+  test "server basic query by name" do
+    {:ok, _} = Sqlitex.Server.start_link(@shared_cache, name: :sql)
+    [row] = Sqlitex.Server.query(:sql, "SELECT * FROM players ORDER BY id LIMIT 1")
+    assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]
+    Sqlitex.Server.stop(:sql)
+  end
+
   test "a basic query returns a list of keyword lists", context do
     [row] = context[:golf_db] |> Sqlitex.query("SELECT * FROM players ORDER BY id LIMIT 1")
     assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]


### PR DESCRIPTION
This request adds GenServer options to `Sqlitex.Server` so that it can be used as a worker.  I also updated the README to reflect the API changes.