### PR TITLE
Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 erl_crash.dump
 *.ez
 /bench/snapshots
+/doc
+/docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ otp_release:
  - 17.4
 elixir:
  - 1.0
+after_script:
+  - MIX_ENV=dev mix deps.get
+  - MIX_ENV=dev mix inch.report

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/mmmries/sqlitex.svg?branch=master)](https://travis-ci.org/mmmries/sqlitex)
+[![Inline docs](http://inch-ci.org/github/mmmries/sqlitex.svg?branch=master)](http://inch-ci.org/github/mmmries/sqlitex)
 
 Sqlitex
 =======
@@ -41,11 +42,6 @@ Sqlitex.Server.query(Sqlitex.Server,
                       INNER JOIN courses AS c ON g.course_id = c.id
                       ORDER BY g.played_at DESC LIMIT 10")
 ```
-
-Benchmarks
-==========
-
-I'm using [Benchfella](https://github.com/alco/benchfella) to keep track of our performance for some of the basic operations. If you want to check benchmark speeds just install benchfella and then run `mix bench` to run the stats.
 
 Plans
 =====

--- a/mix.exs
+++ b/mix.exs
@@ -20,12 +20,15 @@ defmodule Sqlitex.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:esqlite, "~> 0.1.0"}
+      {:esqlite, "~> 0.1.0"},
+
+      {:ex_doc, "~> 0.7", only: :dev},
+      {:inch_ex, "~> 0.2", only: :dev},
     ]
   end
 
   defp package do
-   [contributors: ["Michael Ries"],
+   [contributors: ["Michael Ries", "Jason M Barnes"],
      licenses: ["MIT"],
      links: %{github: "https://github.com/mmmries/sqlitex"}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,4 @@
-%{"esqlite": {:hex, :esqlite, "0.1.0"}}
+%{"esqlite": {:hex, :esqlite, "0.1.0"},
+  "ex_doc": {:hex, :ex_doc, "0.7.2"},
+  "inch_ex": {:hex, :inch_ex, "0.2.4"},
+  "poison": {:hex, :poison, "1.4.0"}}


### PR DESCRIPTION
Fixes #13 

Adds `ex_doc` and `inch_ex` to generate and track the documentation for our project. This means that when we release future versions we will need to remember to do the following:

```
$ # do this after mix hex.publish
$ mix docs
$ mix hex.docs
```

That will generate a new copy of the docs and upload them for the new gem version.

An extra special thank you to @jazzyb for helping out so much on the project and getting me excited about the project again when i was feeling lazy :heart: :hearts: :two_hearts: :heart: :hearts: :two_hearts: :heart: :hearts: :two_hearts: 