### PR TITLE
Fix for Issue #15

### DIFF
--- a/lib/sqlitex/row.ex
+++ b/lib/sqlitex/row.ex
@@ -6,6 +6,9 @@ defmodule Sqlitex.Row do
   end
 
   defp build_row(types, columns, row, into) do
+    types = Enum.map(types, fn type ->
+      type |> Atom.to_string |> String.downcase
+    end)
     values = row |> Tuple.to_list |> Enum.zip(types) |> Enum.map(&translate_value/1)
 
     columns
@@ -13,7 +16,7 @@ defmodule Sqlitex.Row do
       |> Enum.into(into)
   end
 
-  defp translate_value({str, :datetime}) do
+  defp translate_value({str, "datetime"}) do
     <<yr::binary-size(4), "-", mo::binary-size(2), "-", da::binary-size(2), " ", hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2), ".", _fr::binary-size(6)>> = str
     {{String.to_integer(yr), String.to_integer(mo), String.to_integer(da)},{String.to_integer(hr), String.to_integer(mi), String.to_integer(se)}}
   end

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -79,4 +79,13 @@ defmodule SqlitexTest do
     assert [] == Sqlitex.query(db, "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER)")
     Sqlitex.close(db)
   end
+
+  test "it handles different cases of column types" do
+    {:ok, db} = Sqlitex.open(":memory:")
+    :ok = Sqlitex.exec(db, "CREATE TABLE t (inserted_at DATETIME, updated_at DateTime)")
+    :ok = Sqlitex.exec(db, "INSERT INTO t VALUES ('2012-10-14 05:46:28.312941', '2012-10-14 05:46:35.758815')")
+    [row] = Sqlitex.query(db, "SELECT inserted_at, updated_at FROM t")
+    assert row[:inserted_at] == {{2012, 10, 14}, {5, 46, 28}}
+    assert row[:updated_at] == {{2012, 10, 14}, {5, 46, 35}}
+  end
 end


### PR DESCRIPTION
Converts all column types to lowercase strings so that no matter what the upcase/downcase distribution of letters, the types will be interpreted correctly.

@mmmries:  I noticed you have given me write access to the repo, and I could commit it myself.  I'll leave it open for a couple of days to give you a chance to review it if you'd like.

Thanks!