### PR TITLE
Fix bugs found by Ecto integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: elixir
 otp_release:
  - 17.4
 elixir:
- - 1.0
+ - 1.0.2
+ - 1.0.3
+ - 1.0.4
 after_script:
   - MIX_ENV=dev mix deps.get
   - MIX_ENV=dev mix inch.report

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -58,7 +58,12 @@ defmodule Sqlitex do
   end
 
   defp query_options(opts) do
-    params = Keyword.get(opts, :bind, [])
+    params = opts
+    |> Keyword.get(:bind, [])
+    |> Enum.map(fn
+      nil -> :undefined
+      other -> other
+    end)
     into = Keyword.get(opts, :into, [])
     {params, into}
   end

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -50,11 +50,14 @@ defmodule Sqlitex do
 
   defp bind_and_query(statement, opts) do
     {params, into} = query_options(opts)
-    :ok = :esqlite3.bind(statement, params)
-    types = :esqlite3.column_types(statement)
-    columns = :esqlite3.column_names(statement)
-    rows = :esqlite3.fetchall(statement)
-    return_rows_or_error(types, columns, rows, into)
+    case :esqlite3.bind(statement, params) do
+      {:error, _}=error -> error
+      :ok ->
+        types = :esqlite3.column_types(statement)
+        columns = :esqlite3.column_names(statement)
+        rows = :esqlite3.fetchall(statement)
+        return_rows_or_error(types, columns, rows, into)
+    end
   end
 
   defp query_options(opts) do

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -71,16 +71,15 @@ defmodule Sqlitex do
       nil -> :undefined
       true -> 1
       false -> 0
-      {{_yr, _mo, _da}, {_hr, _mi, _se}}=datetime -> datetime_to_string(datetime)
-      {{yr, mo, da}, {hr, mi, se, _usecs}} -> datetime_to_string({{yr, mo, da}, {hr, mi, se}})
+      datetime={{_yr, _mo, _da}, {_hr, _mi, _se, _usecs}} -> datetime_to_string(datetime)
       other -> other
     end)
   end
 
   # Translate the given Erlang datetime tuple to an appropriate string for
   # SQLite.  Microseconds are zeroed.
-  defp datetime_to_string({{yr, mo, da}, {hr, mi, se}}) do
-    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".000000"]
+  defp datetime_to_string({{yr, mo, da}, {hr, mi, se, usecs}}) do
+    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".", zero_pad(usecs, 6)]
     |> Enum.join
   end
 

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -19,12 +19,7 @@ defmodule Sqlitex do
     :esqlite3.exec(sql, db)
   end
 
-  def query(db, sql, opts \\ []) do
-    case :esqlite3.prepare(sql, db) do
-      {:ok, statement} -> bind_and_query(statement, opts)
-      {:error, _}=error -> error
-    end
-  end
+  def query(db, sql, opts \\ []), do: Sqlitex.Query.query(db, sql, opts)
 
   @doc """
   Create a new table `name` where `table_opts` are a list of table constraints
@@ -46,54 +41,5 @@ defmodule Sqlitex do
   def create_table(db, name, table_opts \\ [], cols) do
     stmt = Sqlitex.SqlBuilder.create_table(name, table_opts, cols)
     exec(db, stmt)
-  end
-
-  defp bind_and_query(statement, opts) do
-    {params, into} = query_options(opts)
-    case :esqlite3.bind(statement, params) do
-      {:error, _}=error -> error
-      :ok ->
-        types = :esqlite3.column_types(statement)
-        columns = :esqlite3.column_names(statement)
-        rows = :esqlite3.fetchall(statement)
-        return_rows_or_error(types, columns, rows, into)
-    end
-  end
-
-  defp query_options(opts) do
-    params = opts |> Keyword.get(:bind, []) |> translate_bindings
-    into = Keyword.get(opts, :into, [])
-    {params, into}
-  end
-
-  defp translate_bindings(params) do
-    Enum.map(params, fn
-      nil -> :undefined
-      true -> 1
-      false -> 0
-      datetime={{_yr, _mo, _da}, {_hr, _mi, _se, _usecs}} -> datetime_to_string(datetime)
-      other -> other
-    end)
-  end
-
-  # Translate the given Erlang datetime tuple to an appropriate string for
-  # SQLite.  Microseconds are zeroed.
-  defp datetime_to_string({{yr, mo, da}, {hr, mi, se, usecs}}) do
-    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".", zero_pad(usecs, 6)]
-    |> Enum.join
-  end
-
-  defp zero_pad(num, len) do
-    str = Integer.to_string num
-    String.duplicate("0", len - String.length(str)) <> str
-  end
-
-  defp return_rows_or_error(_, _, {:error, _} = error, _), do: error
-  defp return_rows_or_error({:error, :no_columns}, columns, rows, into), do: return_rows_or_error({}, columns, rows, into)
-  defp return_rows_or_error({:error, _} = error, _columns, _rows, _into), do: error
-  defp return_rows_or_error(types, {:error, :no_columns}, rows, into), do: return_rows_or_error(types, {}, rows, into)
-  defp return_rows_or_error(_types, {:error, _} = error, _rows, _into), do: error
-  defp return_rows_or_error(types, columns, rows, into) do
-    Sqlitex.Row.from(Tuple.to_list(types), Tuple.to_list(columns), rows, into)
   end
 end

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -58,14 +58,20 @@ defmodule Sqlitex do
   end
 
   defp query_options(opts) do
-    params = opts
+    params = bindings(opts)
+    into = Keyword.get(opts, :into, [])
+    {params, into}
+  end
+
+  defp bindings(opts) do
+    opts
     |> Keyword.get(:bind, [])
     |> Enum.map(fn
       nil -> :undefined
+      true -> 1
+      false -> 0
       other -> other
     end)
-    into = Keyword.get(opts, :into, [])
-    {params, into}
   end
 
   defp return_rows_or_error(_, _, {:error, _} = error, _), do: error

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -71,8 +71,22 @@ defmodule Sqlitex do
       nil -> :undefined
       true -> 1
       false -> 0
+      {{_yr, _mo, _da}, {_hr, _mi, _se}}=datetime -> datetime_to_string(datetime)
+      {{yr, mo, da}, {hr, mi, se, _usecs}} -> datetime_to_string({{yr, mo, da}, {hr, mi, se}})
       other -> other
     end)
+  end
+
+  # Translate the given Erlang datetime tuple to an appropriate string for
+  # SQLite.  Microseconds are zeroed.
+  defp datetime_to_string({{yr, mo, da}, {hr, mi, se}}) do
+    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".000000"]
+    |> Enum.join
+  end
+
+  defp zero_pad(num, len) do
+    str = Integer.to_string num
+    String.duplicate("0", len - String.length(str)) <> str
   end
 
   defp return_rows_or_error(_, _, {:error, _} = error, _), do: error

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -58,15 +58,13 @@ defmodule Sqlitex do
   end
 
   defp query_options(opts) do
-    params = bindings(opts)
+    params = opts |> Keyword.get(:bind, []) |> translate_bindings
     into = Keyword.get(opts, :into, [])
     {params, into}
   end
 
-  defp bindings(opts) do
-    opts
-    |> Keyword.get(:bind, [])
-    |> Enum.map(fn
+  defp translate_bindings(params) do
+    Enum.map(params, fn
       nil -> :undefined
       true -> 1
       false -> 0

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -1,0 +1,88 @@
+defmodule Sqlitex.Query do
+  use Pipe
+
+  defstruct bindings: [],
+            column_names: [],
+            column_types: [],
+            database: nil,
+            into: [],
+            raw_data: [],
+            sql: nil,
+            statement: nil
+
+  def query(db, sql, opts \\ []) do
+    pipe_matching {:ok, _},
+      {:ok, %Sqlitex.Query{bindings: bindings_from_opts(opts), into: into_from_opts(opts), database: db, sql: sql}}
+        |> prepare
+        |> bind_values
+        |> column_types
+        |> column_names
+        |> fetch_data
+        |> into_rows
+  end
+
+  defp bind_values({:ok, %Sqlitex.Query{bindings: bindings, statement: statement}=query}) do
+    case :esqlite3.bind(statement, bindings) do
+      {:error,_}=error -> error
+      :ok -> {:ok, query}
+    end
+  end
+
+  defp bindings_from_opts(opts), do: opts |> Keyword.get(:bind, []) |> translate_bindings
+
+  defp column_names({:ok, %Sqlitex.Query{statement: statement}=query}) do
+    case :esqlite3.column_names(statement) do
+      {:error, :no_columns} -> {:ok, %Sqlitex.Query{query | column_names: {}}}
+      {:error, _}=other -> other
+      names -> {:ok, %Sqlitex.Query{query | column_names: names}}
+    end
+  end
+
+  defp column_types({:ok, %Sqlitex.Query{statement: statement}=query}) do
+    case :esqlite3.column_types(statement) do
+      {:error, :no_columns} -> {:ok, %Sqlitex.Query{query | column_types: {}}}
+      {:error, _}=other -> other
+      types -> {:ok, %Sqlitex.Query{query | column_types: types}}
+    end
+  end
+
+  defp datetime_to_string({{yr, mo, da}, {hr, mi, se, usecs}}) do
+    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".", zero_pad(usecs, 6)]
+    |> Enum.join
+  end
+
+  defp fetch_data({:ok, %Sqlitex.Query{statement: statement}=query}) do
+    case :esqlite3.fetchall(statement) do
+      {:error,_}=other -> other
+      raw_data -> {:ok, %Sqlitex.Query{query | raw_data: raw_data}}
+    end
+  end
+
+  defp into_from_opts(opts), do: Keyword.get(opts, :into, [])
+
+  defp prepare({:ok, %Sqlitex.Query{sql: sql, database: database}=query}) do
+    case :esqlite3.prepare(sql, database) do
+      {:ok, statement} -> {:ok, %Sqlitex.Query{query | statement: statement}}
+      other -> other
+    end
+  end
+
+  defp into_rows({:ok, %Sqlitex.Query{column_types: types, column_names: names, raw_data: raw_data, into: into}}) do
+    Sqlitex.Row.from(Tuple.to_list(types), Tuple.to_list(names), raw_data, into)
+  end
+
+  defp translate_bindings(params) do
+    Enum.map(params, fn
+      nil -> :undefined
+      true -> 1
+      false -> 0
+      datetime={{_yr, _mo, _da}, {_hr, _mi, _se, _usecs}} -> datetime_to_string(datetime)
+      other -> other
+    end)
+  end
+
+  defp zero_pad(num, len) do
+    str = Integer.to_string num
+    String.duplicate("0", len - String.length(str)) <> str
+  end
+end

--- a/lib/sqlitex/row.ex
+++ b/lib/sqlitex/row.ex
@@ -23,8 +23,8 @@ defmodule Sqlitex.Row do
   end
 
   defp translate_value({str, "datetime"}) when is_binary(str) do
-    <<yr::binary-size(4), "-", mo::binary-size(2), "-", da::binary-size(2), " ", hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2), ".", _fr::binary-size(6)>> = str
-    {{String.to_integer(yr), String.to_integer(mo), String.to_integer(da)},{String.to_integer(hr), String.to_integer(mi), String.to_integer(se)}}
+    <<yr::binary-size(4), "-", mo::binary-size(2), "-", da::binary-size(2), " ", hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2), ".", fr::binary-size(6)>> = str
+    {{String.to_integer(yr), String.to_integer(mo), String.to_integer(da)},{String.to_integer(hr), String.to_integer(mi), String.to_integer(se), String.to_integer(fr)}}
   end
 
   defp translate_value({0, "boolean"}), do: false

--- a/lib/sqlitex/row.ex
+++ b/lib/sqlitex/row.ex
@@ -16,17 +16,19 @@ defmodule Sqlitex.Row do
       |> Enum.into(into)
   end
 
-  defp translate_value({str, "datetime"}) do
+  ## Convert SQLite values/types to Elixir types
+
+  defp translate_value({:undefined, _type}) do
+    nil
+  end
+
+  defp translate_value({str, "datetime"}) when is_binary(str) do
     <<yr::binary-size(4), "-", mo::binary-size(2), "-", da::binary-size(2), " ", hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2), ".", _fr::binary-size(6)>> = str
     {{String.to_integer(yr), String.to_integer(mo), String.to_integer(da)},{String.to_integer(hr), String.to_integer(mi), String.to_integer(se)}}
   end
 
   defp translate_value({0, "boolean"}), do: false
   defp translate_value({1, "boolean"}), do: true
-
-  defp translate_value({:undefined,_type}) do
-    nil
-  end
 
   defp translate_value({val, _type}) do
     val

--- a/lib/sqlitex/row.ex
+++ b/lib/sqlitex/row.ex
@@ -21,6 +21,9 @@ defmodule Sqlitex.Row do
     {{String.to_integer(yr), String.to_integer(mo), String.to_integer(da)},{String.to_integer(hr), String.to_integer(mi), String.to_integer(se)}}
   end
 
+  defp translate_value({0, "boolean"}), do: false
+  defp translate_value({1, "boolean"}), do: true
+
   defp translate_value({:undefined,_type}) do
     nil
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule Sqlitex.Mixfile do
   defp deps do
     [
       {:esqlite, "~> 0.1.0"},
+      {:pipe, "~> 0.0.2"},
 
       {:earmark, ">= 0.0.0", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,5 @@
   "esqlite": {:hex, :esqlite, "0.1.0"},
   "ex_doc": {:hex, :ex_doc, "0.7.2"},
   "inch_ex": {:hex, :inch_ex, "0.2.4"},
+  "pipe": {:hex, :pipe, "0.0.2"},
   "poison": {:hex, :poison, "1.4.0"}}

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -94,11 +94,21 @@ defmodule SqlitexTest do
     assert row[:updated_at] == {{2012, 10, 14}, {5, 46, 35}}
   end
 
-  test "it returns nil" do
+  test "it inserts nil" do
     {:ok, db} = Sqlitex.open(":memory:")
     :ok = Sqlitex.exec(db, "CREATE TABLE t (a INTEGER)")
     [] = Sqlitex.query(db, "INSERT INTO t VALUES (?1)", bind: [nil])
     [row] = Sqlitex.query(db, "SELECT a FROM t")
     assert row[:a] == nil
+  end
+
+  test "it inserts boolean values" do
+    {:ok, db} = Sqlitex.open(":memory:")
+    :ok = Sqlitex.exec(db, "CREATE TABLE t (id INTEGER, a BOOLEAN)")
+    [] = Sqlitex.query(db, "INSERT INTO t VALUES (?1, ?2)", bind: [1, true])
+    [] = Sqlitex.query(db, "INSERT INTO t VALUES (?1, ?2)", bind: [2, false])
+    [row1, row2] = Sqlitex.query(db, "SELECT a FROM t ORDER BY id")
+    assert row1[:a] == true
+    assert row2[:a] == false
   end
 end

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -111,4 +111,12 @@ defmodule SqlitexTest do
     assert row1[:a] == true
     assert row2[:a] == false
   end
+
+  test "it inserts Erlang datetime tuples" do
+    {:ok, db} = Sqlitex.open(":memory:")
+    :ok = Sqlitex.exec(db, "CREATE TABLE t (dt DATETIME)")
+    [] = Sqlitex.query(db, "INSERT INTO t VALUES (?)", bind: [{{1985, 10, 26}, {1, 20, 0}}])
+    [row] = Sqlitex.query(db, "SELECT dt FROM t")
+    assert row[:dt] == {{1985, 10, 26}, {1, 20, 0}}
+  end
 end

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -14,14 +14,14 @@ defmodule SqlitexTest do
   test "server basic query" do
     {:ok, conn} = Sqlitex.Server.start_link(@shared_cache)
     [row] = Sqlitex.Server.query(conn, "SELECT * FROM players ORDER BY id LIMIT 1")
-    assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]
+    assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28,318107}}, updated_at: {{2013,09,06},{22,29,36,610911}}, type: nil]
     Sqlitex.Server.stop(conn)
   end
 
   test "server basic query by name" do
     {:ok, _} = Sqlitex.Server.start_link(@shared_cache, name: :sql)
     [row] = Sqlitex.Server.query(:sql, "SELECT * FROM players ORDER BY id LIMIT 1")
-    assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]
+    assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28,318107}}, updated_at: {{2013,09,06},{22,29,36,610911}}, type: nil]
     Sqlitex.Server.stop(:sql)
   end
 
@@ -32,12 +32,12 @@ defmodule SqlitexTest do
 
   test "a basic query returns a list of keyword lists", context do
     [row] = context[:golf_db] |> Sqlitex.query("SELECT * FROM players ORDER BY id LIMIT 1")
-    assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]
+    assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28,318107}}, updated_at: {{2013,09,06},{22,29,36,610911}}, type: nil]
   end
 
   test "a basic query returns a list of maps when into: %{} is given", context do
     [row] = context[:golf_db] |> Sqlitex.query("SELECT * FROM players ORDER BY id LIMIT 1", into: %{})
-    assert row == %{id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil}
+    assert row == %{id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28,318107}}, updated_at: {{2013,09,06},{22,29,36,610911}}, type: nil}
   end
 
   test "with_db" do
@@ -45,7 +45,7 @@ defmodule SqlitexTest do
       Sqlitex.query(db, "SELECT * FROM players ORDER BY id LIMIT 1")
     end)
 
-    assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]
+    assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28,318107}}, updated_at: {{2013,09,06},{22,29,36,610911}}, type: nil]
   end
 
   test "table creation works as expected" do
@@ -90,8 +90,8 @@ defmodule SqlitexTest do
     :ok = Sqlitex.exec(db, "CREATE TABLE t (inserted_at DATETIME, updated_at DateTime)")
     :ok = Sqlitex.exec(db, "INSERT INTO t VALUES ('2012-10-14 05:46:28.312941', '2012-10-14 05:46:35.758815')")
     [row] = Sqlitex.query(db, "SELECT inserted_at, updated_at FROM t")
-    assert row[:inserted_at] == {{2012, 10, 14}, {5, 46, 28}}
-    assert row[:updated_at] == {{2012, 10, 14}, {5, 46, 35}}
+    assert row[:inserted_at] == {{2012, 10, 14}, {5, 46, 28, 312941}}
+    assert row[:updated_at] == {{2012, 10, 14}, {5, 46, 35, 758815}}
   end
 
   test "it inserts nil" do
@@ -115,8 +115,8 @@ defmodule SqlitexTest do
   test "it inserts Erlang datetime tuples" do
     {:ok, db} = Sqlitex.open(":memory:")
     :ok = Sqlitex.exec(db, "CREATE TABLE t (dt DATETIME)")
-    [] = Sqlitex.query(db, "INSERT INTO t VALUES (?)", bind: [{{1985, 10, 26}, {1, 20, 0}}])
+    [] = Sqlitex.query(db, "INSERT INTO t VALUES (?)", bind: [{{1985, 10, 26}, {1, 20, 0, 666}}])
     [row] = Sqlitex.query(db, "SELECT dt FROM t")
-    assert row[:dt] == {{1985, 10, 26}, {1, 20, 0}}
+    assert row[:dt] == {{1985, 10, 26}, {1, 20, 0, 666}}
   end
 end

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -25,6 +25,11 @@ defmodule SqlitexTest do
     Sqlitex.Server.stop(:sql)
   end
 
+  test "that it returns an error for a bad query" do
+    {:ok, _} = Sqlitex.Server.start_link(":memory:", name: :bad_create)
+    assert {:error, {:sqlite_error, 'near "WHAT": syntax error'}} == Sqlitex.Server.query(:bad_create, "CREATE WHAT")
+  end
+
   test "a basic query returns a list of keyword lists", context do
     [row] = context[:golf_db] |> Sqlitex.query("SELECT * FROM players ORDER BY id LIMIT 1")
     assert row == [id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -93,4 +93,12 @@ defmodule SqlitexTest do
     assert row[:inserted_at] == {{2012, 10, 14}, {5, 46, 28}}
     assert row[:updated_at] == {{2012, 10, 14}, {5, 46, 35}}
   end
+
+  test "it returns nil" do
+    {:ok, db} = Sqlitex.open(":memory:")
+    :ok = Sqlitex.exec(db, "CREATE TABLE t (a INTEGER)")
+    [] = Sqlitex.query(db, "INSERT INTO t VALUES (?1)", bind: [nil])
+    [row] = Sqlitex.query(db, "SELECT a FROM t")
+    assert row[:a] == nil
+  end
 end


### PR DESCRIPTION
There are quite a few changes in this patch, but they all addresses only two major issues:

1. Errors from `:esqlite3.prepare/2` and `:esqlite3.bind/2` are now passed to the calling function instead of throwing match errors.
2. Conversions to and from Elixir/Erlang types and SQLite values.

See the new test cases for usage.  Let me know what you think.

(One thing to note is the conversion from datetime tuples of the form `{{year, month, day}, {hour, min, sec, usecs}}` to strings.  We already handled the Erlang datetime tuple, but the Ecto code likes to make use of one with microseconds.  I don't know if this type of tuple is used anywhere else in the Elixir/Erlang world.  If it seems too Ecto specific, then I can put it in the Sqlite.Ecto code instead.  To keep these datetime types consistent with the Erlang datetime, I truncate the microseconds value.)