### PR TITLE
Passes timeout option to GenServer.call/3

### DIFF
--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -40,12 +40,12 @@ defmodule Sqlitex.Server do
 
   ## Public API
 
-  def exec(pid, sql) do
-    GenServer.call(pid, {:exec, sql})
+  def exec(pid, sql, opts \\ []) do
+    GenServer.call(pid, {:exec, sql}, timeout(opts))
   end
 
   def query(pid, sql, opts \\ []) do
-    GenServer.call(pid, {:query, sql, opts})
+    GenServer.call(pid, {:query, sql, opts}, timeout(opts))
   end
 
   def create_table(pid, name, table_opts \\ [], cols) do
@@ -55,4 +55,8 @@ defmodule Sqlitex.Server do
   def stop(pid) do
     GenServer.cast(pid, :stop)
   end
+
+  ## Helpers
+
+  defp timeout(kwopts), do: Keyword.get(kwopts, :timeout, 5000)
 end

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -119,4 +119,10 @@ defmodule SqlitexTest do
     [row] = Sqlitex.query(db, "SELECT dt FROM t")
     assert row[:dt] == {{1985, 10, 26}, {1, 20, 0, 666}}
   end
+
+  test "server query times out" do
+    {:ok, conn} = Sqlitex.Server.start_link(":memory:")
+    assert match?({:timeout, _},
+      catch_exit(Sqlitex.Server.query(conn, "SELECT * FROM sqlite_master", timeout: 0)))
+  end
 end


### PR DESCRIPTION
New Ecto 0.12 integration tests to be passed :)

I added timeout option checking to `Sqlitex.Server.exec/3` and `query/3`.  I did not add the check to `Sqlitex.Server.create_table/4` because the current `table_opts` is the third of four arguments and is already optional.  We could move the table options to the end of the call like we do for the exec and query functions.

Ultimately, I decided to just ignore `create_table` for now.  I'll opt to revisit it later.