### PR TITLE
Remove no column workaround

### DIFF
--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -32,7 +32,6 @@ defmodule Sqlitex.Query do
 
   defp column_names({:ok, %Sqlitex.Query{statement: statement}=query}) do
     case :esqlite3.column_names(statement) do
-      {:error, :no_columns} -> {:ok, %Sqlitex.Query{query | column_names: {}}}
       {:error, _}=other -> other
       names -> {:ok, %Sqlitex.Query{query | column_names: names}}
     end
@@ -40,7 +39,6 @@ defmodule Sqlitex.Query do
 
   defp column_types({:ok, %Sqlitex.Query{statement: statement}=query}) do
     case :esqlite3.column_types(statement) do
-      {:error, :no_columns} -> {:ok, %Sqlitex.Query{query | column_types: {}}}
       {:error, _}=other -> other
       types -> {:ok, %Sqlitex.Query{query | column_types: types}}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Sqlitex.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:esqlite, "~> 0.1.0"},
+      {:esqlite, "~> 0.2.0"},
       {:pipe, "~> 0.0.2"},
       {:decimal, "~> 1.1.0"},
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.16"},
-  "esqlite": {:hex, :esqlite, "0.1.0"},
+  "esqlite": {:hex, :esqlite, "0.2.0"},
   "ex_doc": {:hex, :ex_doc, "0.7.2"},
   "inch_ex": {:hex, :inch_ex, "0.2.4"},
   "pipe": {:hex, :pipe, "0.0.2"},


### PR DESCRIPTION
resolves #21

Bumps the dependency to on esqlite to `0.2.0`

Removes the workaround for `{:error, :no_columns}`. We still need the `case` statements because we need to capture the types/names and merge them into the `Sqlitex.Query` struct, so this doesn't end making a huge difference, but it is nice to remove two cases.

Did I miss any tests that should be removed. I didn't see any that were specific to the `no_columns` workaround. i think all the tests cases could still be valuable.

/cc @jazzyb 