### PR TITLE
Allow re-use of prepared statements

### DIFF
--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -20,6 +20,7 @@ defmodule Sqlitex do
   end
 
   def query(db, sql, opts \\ []), do: Sqlitex.Query.query(db, sql, opts)
+  def query!(db, sql, opts \\ []), do: Sqlitex.Query.query!(db, sql, opts)
 
   @doc """
   Create a new table `name` where `table_opts` are a list of table constraints

--- a/lib/sqlitex/errors.ex
+++ b/lib/sqlitex/errors.ex
@@ -29,3 +29,11 @@ defmodule Sqlitex.Statement.FetchAllError do
     "Fetch all failed: #{inspect error.reason}"
   end
 end
+
+defmodule Sqlitex.Statement.ExecError do
+  defexception [:reason]
+
+  def message(error) do
+    "Exec failed: #{inspect error.reason}"
+  end
+end

--- a/lib/sqlitex/errors.ex
+++ b/lib/sqlitex/errors.ex
@@ -1,0 +1,31 @@
+defmodule Sqlitex.QueryError do
+  defexception [:reason]
+
+  def message(error) do
+    "Query failed: #{inspect error.reason}"
+  end
+end
+
+defmodule Sqlitex.Statement.PrepareError do
+  defexception [:reason]
+
+  def message(error) do
+    "Prepare statement failed: #{inspect error.reason}"
+  end
+end
+
+defmodule Sqlitex.Statement.BindValuesError do
+  defexception [:reason]
+
+  def message(error) do
+    "Bind values failed: #{inspect error.reason}"
+  end
+end
+
+defmodule Sqlitex.Statement.FetchAllError do
+  defexception [:reason]
+
+  def message(error) do
+    "Fetch all failed: #{inspect error.reason}"
+  end
+end

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -19,7 +19,7 @@ defmodule Sqlitex.Query do
   * `into` - The collection to put results into.  This defaults to a list.
 
   ## Returns
-  * {:ok, results} on success
+  * [results...] on success
   * {:error, _} on failure.
   """
   def query(db, sql, opts \\ []) do
@@ -35,8 +35,10 @@ defmodule Sqlitex.Query do
   Returns the results otherwise.
   """
   def query!(db, sql, opts \\ []) do
-    {:ok, results} = query(db, sql, opts)
-    results
+    case query(db, sql, opts) do
+      {:error, reason} -> raise Sqlitex.QueryError, reason: reason
+      results -> results
+    end
   end
 
   defp pipe_ok(x, f) do

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -3,6 +3,25 @@ defmodule Sqlitex.Query do
 
   alias Sqlitex.Statement
 
+  @doc """
+  Runs a query and returns the results.
+
+  ## Parameters
+
+  * `db` - A sqlite database.
+  * `sql` - The query to run as a string.
+  * `opts` - Options to pass into the query.  See below for details.
+
+  ## Options
+
+  * `bind` - If your query has parameters in it, you should provide the options
+    to bind as a list.
+  * `into` - The collection to put results into.  This defaults to a list.
+
+  ## Returns
+  * {:ok, results} on success
+  * {:error, _} on failure.
+  """
   def query(db, sql, opts \\ []) do
     pipe_with &pipe_ok/2,
       Statement.prepare(db, sql)
@@ -10,6 +29,11 @@ defmodule Sqlitex.Query do
       |> Statement.fetch_all(Dict.get(opts, :into, []))
   end
 
+  @doc """
+  Same as `query/3` but raises an error on error.
+
+  Returns the results otherwise.
+  """
   def query!(db, sql, opts \\ []) do
     {:ok, results} = query(db, sql, opts)
     results

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -30,7 +30,7 @@ defmodule Sqlitex.Query do
   end
 
   @doc """
-  Same as `query/3` but raises an error on error.
+  Same as `query/3` but raises a Sqlitex.QueryError on error.
 
   Returns the results otherwise.
   """

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -1,87 +1,24 @@
 defmodule Sqlitex.Query do
   use Pipe
 
-  defstruct bindings: [],
-            column_names: [],
-            column_types: [],
-            database: nil,
-            into: [],
-            raw_data: [],
-            sql: nil,
-            statement: nil
+  alias Sqlitex.Statement
 
   def query(db, sql, opts \\ []) do
-    pipe_matching {:ok, _},
-      {:ok, %Sqlitex.Query{bindings: bindings_from_opts(opts), into: into_from_opts(opts), database: db, sql: sql}}
-        |> prepare
-        |> bind_values
-        |> column_types
-        |> column_names
-        |> fetch_data
-        |> into_rows
+    pipe_with &pipe_ok/2,
+      Statement.prepare(db, sql)
+      |> Statement.bind_values(Dict.get(opts, :bind, []))
+      |> Statement.fetch_all(Dict.get(opts, :into, []))
   end
 
-  defp bind_values({:ok, %Sqlitex.Query{bindings: bindings, statement: statement}=query}) do
-    case :esqlite3.bind(statement, bindings) do
-      {:error,_}=error -> error
-      :ok -> {:ok, query}
-    end
+  def query!(db, sql, opts \\ []) do
+    {:ok, results} = query(db, sql, opts)
+    results
   end
 
-  defp bindings_from_opts(opts), do: opts |> Keyword.get(:bind, []) |> translate_bindings
-
-  defp column_names({:ok, %Sqlitex.Query{statement: statement}=query}) do
-    case :esqlite3.column_names(statement) do
-      {:error, _}=other -> other
-      names -> {:ok, %Sqlitex.Query{query | column_names: names}}
-    end
-  end
-
-  defp column_types({:ok, %Sqlitex.Query{statement: statement}=query}) do
-    case :esqlite3.column_types(statement) do
-      {:error, _}=other -> other
-      types -> {:ok, %Sqlitex.Query{query | column_types: types}}
-    end
-  end
-
-  defp datetime_to_string({{yr, mo, da}, {hr, mi, se, usecs}}) do
-    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".", zero_pad(usecs, 6)]
-    |> Enum.join
-  end
-
-  defp fetch_data({:ok, %Sqlitex.Query{statement: statement}=query}) do
-    case :esqlite3.fetchall(statement) do
-      {:error,_}=other -> other
-      raw_data -> {:ok, %Sqlitex.Query{query | raw_data: raw_data}}
-    end
-  end
-
-  defp into_from_opts(opts), do: Keyword.get(opts, :into, [])
-
-  defp prepare({:ok, %Sqlitex.Query{sql: sql, database: database}=query}) do
-    case :esqlite3.prepare(sql, database) do
-      {:ok, statement} -> {:ok, %Sqlitex.Query{query | statement: statement}}
+  defp pipe_ok(x, f) do
+    case x do
+      {:ok, val} -> f.(val)
       other -> other
     end
-  end
-
-  defp into_rows({:ok, %Sqlitex.Query{column_types: types, column_names: names, raw_data: raw_data, into: into}}) do
-    Sqlitex.Row.from(Tuple.to_list(types), Tuple.to_list(names), raw_data, into)
-  end
-
-  defp translate_bindings(params) do
-    Enum.map(params, fn
-      nil -> :undefined
-      true -> 1
-      false -> 0
-      datetime={{_yr, _mo, _da}, {_hr, _mi, _se, _usecs}} -> datetime_to_string(datetime)
-      %Decimal{sign: sign, coef: coef, exp: exp} -> sign * coef * :math.pow(10, exp)
-      other -> other
-    end)
-  end
-
-  defp zero_pad(num, len) do
-    str = Integer.to_string num
-    String.duplicate("0", len - String.length(str)) <> str
   end
 end

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -1,0 +1,195 @@
+defmodule Sqlitex.Statement do
+  @moduledoc """
+  Provides an interface for working with sqlite prepared statements.
+
+  """
+
+  use Pipe
+
+  defstruct database: nil,
+            statement: nil,
+            column_names: [],
+            column_types: []
+
+  @doc """
+  Prepare a Sqlitex.Statement
+
+  ## Parameters
+
+  * `db` - The database to prepare the statement for.
+  * `sql` - The SQL of the statement to prepare.
+
+  ## Returns
+
+  * `{:ok, statement}` on success
+  * See `:esqlite3.prepare` for errors.
+  """
+  def prepare(db, sql) do
+    pipe_with &pipe_ok/2,
+      do_prepare(db, sql)
+      |> get_column_names
+      |> get_column_types
+  end
+
+  @doc """
+  Prepare a Sqlitex.Statement
+
+  ## Parameters
+
+  * `db` - The database to prepare the statement for.
+  * `sql` - The SQL of the statement to prepare.
+
+  ## Returns
+  * `statement` on success
+  * Errors on failure.
+  """
+  def prepare!(db, sql) do
+    {:ok, statement} = prepare(db, sql)
+    statement
+  end
+
+  @doc """
+  Binds values to a Sqlitex.Statement
+
+  ## Parameters
+
+  * `statement` - The statement to bind values into.
+  * `values` - A list of values to bind into the statement.
+
+  ## Returns
+
+  * `{:ok, statement}` on success
+  * See `:esqlite3.prepare` for errors.
+
+  ## Value transformations
+
+  Some values will be transformed before insertion into the database.
+
+  * `nil` - Converted to :undefined
+  * `true` - Converted to 1
+  * `false` - Converted to 0
+  * `datetime` - Converted into a string.  See datetime_to_string
+  * `%Decimal` -  Converted into a number.
+  """
+  def bind_values(statement, values) do
+    case :esqlite3.bind(statement.statement, translate_bindings(values)) do
+      {:error, _}=error -> error
+      :ok -> {:ok, statement}
+    end
+  end
+
+  @doc """
+  Binds values to a Sqlitex.Statement
+
+  ## Parameters
+
+  * `statement` - The statement to bind values into.
+  * `values` - A list of values to bind into the statement.
+  ## Returns
+
+  ## Returns
+  * `statement` on success
+  * Errors on failure.
+  """
+  def bind_values!(statement, values) do
+    {:ok, statement} = bind_values(statement, values)
+    statement
+  end
+
+  @doc """
+  Fetches all rows using a statement.
+
+  Should be called after the statement has been bound.
+
+  ## Parameters
+
+  * `statement` - The statement to run.
+  * `into` - The collection to put the results into. Defaults to an empty list.
+
+  ## Returns
+
+  * `{:ok, results}`
+  * `{:error, error}`
+  """
+  def fetch_all(statement, into \\ []) do
+    case :esqlite3.fetchall(statement.statement) do
+      {:error, _}=other -> other
+      raw_data ->
+        Sqlitex.Row.from(
+          Tuple.to_list(statement.column_types),
+          Tuple.to_list(statement.column_names),
+          raw_data, into
+        )
+    end
+  end
+
+  @doc """
+  Fetches all rows using a statement.
+
+  Should be called after the statement has been bound.
+
+  ## Parameters
+
+  * `statement` - The statement to run.
+  * `into` - The collection to put the results into. Defaults to an empty list.
+
+  ## Returns
+
+  * `results` on success
+  * Errors on failure.
+  """
+  def fetch_all!(statement, into \\ []) do
+    {:ok, results} = fetch_all(statement, into)
+    results
+  end
+
+  defp do_prepare(db, sql) do
+    case :esqlite3.prepare(sql, db) do
+      {:ok, statement} ->
+        {:ok, %Sqlitex.Statement{database: db, statement: statement}}
+      other -> other
+    end
+  end
+
+  defp get_column_names(%Sqlitex.Statement{statement: sqlite_statement}=statement) do
+    case :esqlite3.column_names(sqlite_statement) do
+      {:error, _}=other -> other
+      names -> {:ok, %Sqlitex.Statement{statement | column_names: names}}
+    end
+  end
+
+  defp get_column_types(%Sqlitex.Statement{statement: sqlite_statement}=statement) do
+    case :esqlite3.column_types(sqlite_statement) do
+      {:error, _}=other -> other
+      types -> {:ok, %Sqlitex.Statement{statement | column_types: types}}
+    end
+  end
+
+  defp translate_bindings(params) do
+    Enum.map(params, fn
+      nil -> :undefined
+      true -> 1
+      false -> 0
+      datetime={{_yr, _mo, _da}, {_hr, _mi, _se, _usecs}} -> datetime_to_string(datetime)
+      %Decimal{sign: sign, coef: coef, exp: exp} -> sign * coef * :math.pow(10, exp)
+      other -> other
+    end)
+  end
+
+  defp datetime_to_string({{yr, mo, da}, {hr, mi, se, usecs}}) do
+    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".", zero_pad(usecs, 6)]
+    |> Enum.join
+  end
+
+  defp zero_pad(num, len) do
+    str = Integer.to_string num
+    String.duplicate("0", len - String.length(str)) <> str
+  end
+
+  defp pipe_ok(x, f) do
+    case x do
+      {:ok, val} -> f.(val)
+      other -> other
+    end
+  end
+end

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -47,16 +47,9 @@ defmodule Sqlitex.Statement do
   end
 
   @doc """
-  Prepare a Sqlitex.Statement
+  Same as `prepare/2` but raises an error on error.
 
-  ## Parameters
-
-  * `db` - The database to prepare the statement for.
-  * `sql` - The SQL of the statement to prepare.
-
-  ## Returns
-  * `statement` on success
-  * Errors on failure.
+  Returns a new statement otherwise.
   """
   def prepare!(db, sql) do
     {:ok, statement} = prepare(db, sql)
@@ -94,17 +87,9 @@ defmodule Sqlitex.Statement do
   end
 
   @doc """
-  Binds values to a Sqlitex.Statement
+  Same as `bind_values/2` but raises an error on error.
 
-  ## Parameters
-
-  * `statement` - The statement to bind values into.
-  * `values` - A list of values to bind into the statement.
-  ## Returns
-
-  ## Returns
-  * `statement` on success
-  * Errors on failure.
+  Returns the statement otherwise.
   """
   def bind_values!(statement, values) do
     {:ok, statement} = bind_values(statement, values)
@@ -139,19 +124,9 @@ defmodule Sqlitex.Statement do
   end
 
   @doc """
-  Fetches all rows using a statement.
+  Same as `fetch_all/2` but raises an error on error.
 
-  Should be called after the statement has been bound.
-
-  ## Parameters
-
-  * `statement` - The statement to run.
-  * `into` - The collection to put the results into. Defaults to an empty list.
-
-  ## Returns
-
-  * `results` on success
-  * Errors on failure.
+  Returns the results otherwise.
   """
   def fetch_all!(statement, into \\ []) do
     {:ok, results} = fetch_all(statement, into)

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -2,6 +2,21 @@ defmodule Sqlitex.Statement do
   @moduledoc """
   Provides an interface for working with sqlite prepared statements.
 
+  ```
+  iex(2)> {:ok, db} = Sqlitex.open(":memory:")
+  iex(3)> Sqlitex.query(db, "CREATE TABLE data (id, name);")
+  []
+  iex(6)> {:ok, statement} = Sqlitex.Statement.prepare(db, "INSERT INTO data VALUES (?, ?);")
+  iex(7)> Sqlitex.Statement.bind_values(statement, [1, "hello"])
+  iex(8)> Sqlitex.Statement.fetch_all(statement)
+  []
+  iex(9)> {:ok, statement} = Sqlitex.Statement.prepare(db, "SELECT * FROM data;")
+  iex(10)> Sqlitex.Statement.fetch_all(statement)
+  [[id: 1, name: "hello"]]
+  iex(11)> Sqlitex.close(db)
+  :ok
+
+  ```
   """
 
   use Pipe

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -52,8 +52,10 @@ defmodule Sqlitex.Statement do
   Returns a new statement otherwise.
   """
   def prepare!(db, sql) do
-    {:ok, statement} = prepare(db, sql)
-    statement
+    case prepare(db, sql) do
+      {:ok, statement} -> statement
+      {:error, reason} -> raise Sqlitex.Statement.PrepareError, reason: reason
+    end
   end
 
   @doc """
@@ -92,8 +94,10 @@ defmodule Sqlitex.Statement do
   Returns the statement otherwise.
   """
   def bind_values!(statement, values) do
-    {:ok, statement} = bind_values(statement, values)
-    statement
+    case bind_values(statement, values) do
+      {:ok, statement} -> statement
+      {:error, reason} -> raise Sqlitex.Statement.BindValuesError, reason: reason
+    end
   end
 
   @doc """
@@ -129,8 +133,10 @@ defmodule Sqlitex.Statement do
   Returns the results otherwise.
   """
   def fetch_all!(statement, into \\ []) do
-    {:ok, results} = fetch_all(statement, into)
-    results
+    case fetch_all(statement, into) do
+      {:ok, results} -> results
+      {:error, reason} -> raise Sqlitex.Statement.FetchAllError, reason: reason
+    end
   end
 
   defp do_prepare(db, sql) do

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -2,6 +2,15 @@ defmodule Sqlitex.Statement do
   @moduledoc """
   Provides an interface for working with sqlite prepared statements.
 
+  Care should be taken when using prepared statements directly - they are not
+  immutable objects like most things in Elixir. Sharing a statement between
+  different processes can cause problems if the processes accidentally
+  interleave operations on the statement. It's a good idea to create different
+  statements per process, or to wrap the statements up in a GenServer to prevent
+  interleaving operations.
+
+  ## Example
+
   ```
   iex(2)> {:ok, db} = Sqlitex.open(":memory:")
   iex(3)> Sqlitex.query(db, "CREATE TABLE data (id, name);")

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -120,6 +120,23 @@ defmodule SqlitexTest do
     assert row[:dt] == {{1985, 10, 26}, {1, 20, 0, 666}}
   end
 
+  test "query! returns data" do
+    {:ok, db} = Sqlitex.open(":memory:")
+    :ok = Sqlitex.exec(db, "CREATE TABLE t (num INTEGER)")
+    [] = Sqlitex.query(db, "INSERT INTO t VALUES (?)", bind: [1])
+    results = Sqlitex.query!(db, "SELECT num from t")
+    assert results == [[num: 1]]
+  end
+
+  test "query! throws on error" do
+    {:ok, db} = Sqlitex.open(":memory:")
+    :ok = Sqlitex.exec(db, "CREATE TABLE t (num INTEGER)")
+    [] = Sqlitex.query(db, "INSERT INTO t VALUES (?)", bind: [1])
+    assert_raise Sqlitex.QueryError, "Query failed: {:sqlite_error, 'no such column: nope'}", fn ->
+      [res] = Sqlitex.query!(db, "SELECT nope from t")
+    end
+  end
+
   test "server query times out" do
     {:ok, conn} = Sqlitex.Server.start_link(":memory:")
     assert match?({:timeout, _},

--- a/test/statement_test.exs
+++ b/test/statement_test.exs
@@ -1,0 +1,4 @@
+defmodule StatementTest do
+  use ExUnit.Case, async: true
+  doctest Sqlitex.Statement
+end


### PR DESCRIPTION
I've got an application using Sqlitex that's going to be running for a fairly long time and only ever makes a couple of queries.  When I've been using sqlite in other languages, I'd usually just create a prepared statement once and re-use it multiple times.  This doesn't seem to be something that the Sqlitex API supported, so I've re-arranged things a bit so that it does.

* Created a `Sqlitex.Statement` module.  Most of the code from `Sqlitex.Query` has been moved into this module, though I've made a lot of the functions public when they were private before.
* The `pipe_matching` functionality you were using is pretty cool, though I've modified it slightly - using `pipe_with` to extract the value from the `:ok` tuple before passing it in to the next function.  Makes the interface of the functions slightly tidier in my opinion.
* I've added `!` versions of most of the functions that will just raise errors rather than returning (the idiom used a lot in the Elixir standard library
* I've added documentation of most of the functions, and the Sqlitex.Query function itself.
* The interface of `Sqlitex.Query` has remained the same, but the implementation is much simpler since it just uses `Sqlitex.Statement` now.

This is a fairly big change, so feel free to tell me if there's anything stupid in there.