### PR TITLE
Fix `Sqlitex.Statement.fetch_all!`

### DIFF
--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -24,10 +24,15 @@ defmodule Sqlitex.Query do
   """
 
   def query(db, sql, opts \\ []) do
-    pipe_with &pipe_ok/2,
+    res = pipe_with &pipe_ok/2,
       Statement.prepare(db, sql)
       |> Statement.bind_values(Dict.get(opts, :bind, []))
       |> Statement.fetch_all(Dict.get(opts, :into, []))
+
+    case res do
+      {:ok, results} -> results
+      other -> other
+    end
   end
 
   @doc """

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -143,8 +143,8 @@ defmodule Sqlitex.Statement do
   """
   def fetch_all!(statement, into \\ []) do
     case fetch_all(statement, into) do
-      {:ok, results} -> results
       {:error, reason} -> raise Sqlitex.Statement.FetchAllError, reason: reason
+      results -> results
     end
   end
 

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -21,7 +21,7 @@ defmodule Sqlitex.Statement do
   :ok
   iex(9)> {:ok, statement} = Sqlitex.Statement.prepare(db, "SELECT * FROM data;")
   iex(10)> Sqlitex.Statement.fetch_all(statement)
-  [[id: 1, name: "hello"]]
+  {:ok, [[id: 1, name: "hello"]]}
   iex(11)> Sqlitex.close(db)
   :ok
 
@@ -128,11 +128,11 @@ defmodule Sqlitex.Statement do
     case :esqlite3.fetchall(statement.statement) do
       {:error, _}=other -> other
       raw_data ->
-        Sqlitex.Row.from(
+        {:ok, Sqlitex.Row.from(
           Tuple.to_list(statement.column_types),
           Tuple.to_list(statement.column_names),
           raw_data, into
-        )
+        )}
     end
   end
 
@@ -143,8 +143,8 @@ defmodule Sqlitex.Statement do
   """
   def fetch_all!(statement, into \\ []) do
     case fetch_all(statement, into) do
+      {:ok, results} -> results
       {:error, reason} -> raise Sqlitex.Statement.FetchAllError, reason: reason
-      results -> results
     end
   end
 

--- a/test/statement_test.exs
+++ b/test/statement_test.exs
@@ -1,4 +1,13 @@
 defmodule StatementTest do
   use ExUnit.Case, async: true
   doctest Sqlitex.Statement
+
+  test "fetch_all! works" do
+    {:ok, db} = Sqlitex.open(":memory:")
+
+    result = Sqlitex.Statement.prepare!(db, "PRAGMA user_version;")
+             |> Sqlitex.Statement.fetch_all!
+
+    assert result == [[user_version: 0]]
+  end
 end


### PR DESCRIPTION
`fetch_all!` was incorrectly assuming that `fetch_all` returns `{:ok, results}` - actually it just returns `results`.