### PR TITLE
Support for datetime values without fractional seconds

### DIFF
--- a/lib/sqlitex/row.ex
+++ b/lib/sqlitex/row.ex
@@ -56,10 +56,14 @@ defmodule Sqlitex.Row do
     {String.to_integer(yr), String.to_integer(mo), String.to_integer(da)}
   end
 
-  defp to_time(<<hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2), ".", fr::binary-size(6)>>) do
-    {String.to_integer(hr), String.to_integer(mi), String.to_integer(se), String.to_integer(fr)}
+  defp to_time(<<hr::binary-size(2), ":", mi::binary-size(2)>>) do
+    {String.to_integer(hr), String.to_integer(mi), 0, 0}
   end
   defp to_time(<<hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2)>>) do
     {String.to_integer(hr), String.to_integer(mi), String.to_integer(se), 0}
+  end
+  defp to_time(<<hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2), ".", fr::binary>>) when byte_size(fr) <= 6 do
+    fr = String.to_integer(fr <> String.duplicate("0", 6 - String.length(fr)))
+    {String.to_integer(hr), String.to_integer(mi), String.to_integer(se), fr}
   end
 end

--- a/lib/sqlitex/row.ex
+++ b/lib/sqlitex/row.ex
@@ -56,8 +56,10 @@ defmodule Sqlitex.Row do
     {String.to_integer(yr), String.to_integer(mo), String.to_integer(da)}
   end
 
-  defp to_time(time) do
-    <<hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2), ".", fr::binary-size(6)>> = time
+  defp to_time(<<hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2), ".", fr::binary-size(6)>>) do
     {String.to_integer(hr), String.to_integer(mi), String.to_integer(se), String.to_integer(fr)}
+  end
+  defp to_time(<<hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2)>>) do
+    {String.to_integer(hr), String.to_integer(mi), String.to_integer(se), 0}
   end
 end

--- a/test/row_test.exs
+++ b/test/row_test.exs
@@ -1,0 +1,24 @@
+defmodule Sqlitex.RowTest do
+  use ExUnit.Case
+  import Sqlitex.Row
+
+  test "supports the YYYY-MM-DD HH:MM format" do
+    [row] = from([:datetime],[:test],[{"1988-02-14 15:17"}], %{})
+    assert %{test: {{1988,2,14},{15,17,0,0}}} == row
+  end
+
+  test "supports the YYYY-MM-DD HH:MM:SS format" do
+    [row] = from([:datetime],[:test],[{"1988-02-14 15:17:11"}], %{})
+    assert %{test: {{1988,2,14},{15,17,11,0}}} == row
+  end
+
+  test "supports the YYYY-MM-DD HH:MM:SS.FFF format" do
+    [row] = from([:datetime],[:test],[{"1988-02-14 15:17:11.123"}], %{})
+    assert %{test: {{1988,2,14},{15,17,11,123000}}} == row
+  end
+
+  test "supports the YYYY-MM-DD HH:MM:SS.FFFFFF format" do
+    [row] = from([:datetime],[:test],[{"1988-02-14 15:17:11.123456"}], %{})
+    assert %{test: {{1988,2,14},{15,17,11,123456}}} == row
+  end
+end

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -136,15 +136,6 @@ defmodule SqlitexTest do
     assert row[:dt] == {{1985, 10, 26}, {1, 20, 0, 666}}
   end
 
-  test "it decodes datetime values with or without microseconds" do
-    {:ok, db} = Sqlitex.open(":memory:")
-    :ok = Sqlitex.exec(db, "CREATE TABLE t (dt DATETIME)")
-    [] = Sqlitex.query(db, "INSERT INTO t VALUES ('1978-05-12 15:16:17'), ('1978-05-12 15:16:17.123456')")
-    [row1,row2] = Sqlitex.query(db, "SELECT dt FROM t")
-    assert row1[:dt] == {{1978, 05, 12}, {15, 16, 17, 0}}
-    assert row2[:dt] == {{1978, 05, 12}, {15, 16, 17, 123456}}
-  end
-
   test "query! returns data" do
     {:ok, db} = Sqlitex.open(":memory:")
     :ok = Sqlitex.exec(db, "CREATE TABLE t (num INTEGER)")

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -136,6 +136,15 @@ defmodule SqlitexTest do
     assert row[:dt] == {{1985, 10, 26}, {1, 20, 0, 666}}
   end
 
+  test "it decodes datetime values with or without microseconds" do
+    {:ok, db} = Sqlitex.open(":memory:")
+    :ok = Sqlitex.exec(db, "CREATE TABLE t (dt DATETIME)")
+    [] = Sqlitex.query(db, "INSERT INTO t VALUES ('1978-05-12 15:16:17'), ('1978-05-12 15:16:17.123456')")
+    [row1,row2] = Sqlitex.query(db, "SELECT dt FROM t")
+    assert row1[:dt] == {{1978, 05, 12}, {15, 16, 17, 0}}
+    assert row2[:dt] == {{1978, 05, 12}, {15, 16, 17, 123456}}
+  end
+
   test "query! returns data" do
     {:ok, db} = Sqlitex.open(":memory:")
     :ok = Sqlitex.exec(db, "CREATE TABLE t (num INTEGER)")


### PR DESCRIPTION
It turns out that most of sqlite's [date and time functions](https://www.sqlite.org/lang_datefunc.html) us a format without any fractional seconds.
This commit adds support for querying those values out of the database.

Resolves #27 

@Tica2 this adds support for a datetime string with no fractional seconds, but doesn't handle the case where the string is saved with 3 decimal points (milliseconds), or just a single decimal point (tenths of a second).

Since sqlite is actually just storing this as a string I wonder how far we should go in supporting the different formats. Any ideas @jazzyb or @obmarg?