### PR TITLE
Typespecs

### DIFF
--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -1,13 +1,15 @@
 defmodule Sqlitex do
-  @type sqlite_connection :: {:connection, reference, String.t}
+  @type connection :: {:connection, reference, String.t}
+  @type string_or_charlist :: String.t | char_list
+  @type sqlite_error :: {:error, {:sqlite_error, char_list}}
 
-  @spec close(sqlite_connection) :: :ok
+  @spec close(connection) :: :ok
   def close(db) do
     :esqlite3.close(db)
   end
 
-  @spec open(String.t) :: {:ok, sqlite_connection}
-  @spec open(char_list) :: {:ok, sqlite_connection} | {:error, {atom, char_list}}
+  @spec open(String.t) :: {:ok, connection}
+  @spec open(char_list) :: {:ok, connection} | {:error, {atom, char_list}}
   def open(path) when is_binary(path), do: open(String.to_char_list(path))
   def open(path) do
     :esqlite3.open(path)
@@ -20,6 +22,7 @@ defmodule Sqlitex do
     res
   end
 
+  @spec exec(connection, string_or_charlist) :: :ok | sqlite_error
   def exec(db, sql) do
     :esqlite3.exec(sql, db)
   end

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -1,8 +1,13 @@
 defmodule Sqlitex do
+  @type sqlite_connection :: {:connection, reference, String.t}
+
+  @spec close(sqlite_connection) :: :ok
   def close(db) do
     :esqlite3.close(db)
   end
 
+  @spec open(String.t) :: {:ok, sqlite_connection}
+  @spec open(char_list) :: {:ok, sqlite_connection} | {:error, {atom, char_list}}
   def open(path) when is_binary(path), do: open(String.to_char_list(path))
   def open(path) do
     :esqlite3.open(path)

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -23,6 +23,8 @@ defmodule Sqlitex.Query do
   * {:error, _} on failure.
   """
 
+  @spec query(Sqlitex.connection, String.t | char_list) :: [ [] ] | Sqlitex.sqlite_error
+  @spec query(Sqlitex.connection, String.t | char_list, [bind: [], into: Enum.t]) :: [ Enum.t ] | Sqlitex.sqlite_error
   def query(db, sql, opts \\ []) do
     res = pipe_with &pipe_ok/2,
       Statement.prepare(db, sql)
@@ -40,6 +42,8 @@ defmodule Sqlitex.Query do
 
   Returns the results otherwise.
   """
+  @spec query!(Sqlitex.connection, String.t | char_list) :: [ [] ]
+  @spec query!(Sqlitex.connection, String.t | char_list, [bind: [], into: Enum.t]) :: [ Enum.t ]
   def query!(db, sql, opts \\ []) do
     case query(db, sql, opts) do
       {:error, reason} -> raise Sqlitex.QueryError, reason: reason

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,7 @@ defmodule Sqlitex.Mixfile do
       {:decimal, "~> 1.1.0"},
 
       {:dogma, "~> 0.0", only: :dev},
+      {:dialyze, "~> 0.2.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev},
       {:inch_ex, "~> 0.2", only: :dev},


### PR DESCRIPTION
This is a start to #12 

I'm adding some typespecs and adding a development dependency on `dialyze` so I can locally run `mix dialyze` to make sure that our types are consistent internally.

It turns out that `esqlite` has some type specs because I initially wrote the typespec for `Sqlite.open/1` wrong and dialyzer yelled at me saying that my typespec couldn't be right based on the spec of `:esqlite.open`.

I stopped writing specs when i got to `Sqlitex.create_table` because I wasn't sure how to write the typespec for that function. I thought I should go ahead and open this PR as-is since it already represents a small improvement to the project and if I find this useful I'll add more.