### PR TITLE
Dogma fixes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,4 +21,4 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,11 @@
+use Mix.Config
+
+config :dogma,
+  rule_set: Dogma.RuleSet.All,
+
+  exclude: [
+    ~r(\Atest/test_database.exs),
+  ],
+  additional_config: [
+    LineLength: [max_length: 100]
+  ]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,11 +1,41 @@
 use Mix.Config
 
-config :dogma,
-  rule_set: Dogma.RuleSet.All,
+defmodule Sqlitex.DogmaRuleSet do
+  @behaviour Dogma.RuleSet
+  def rules do
+    [
+      {BarePipeChainStart},
+      {ComparisonToBoolean},
+      {DebuggerStatement},
+      {ExceptionName},
+      {FinalCondition},
+      {FinalNewline},
+      {FunctionArity, max: 4},
+      {FunctionName},
+      {HardTabs},
+      {LineLength, max_length: 100},
+      {LiteralInCondition},
+      {LiteralInInterpolation},
+      {MatchInCondition},
+      {ModuleAttributeName},
+      {ModuleDoc},
+      {ModuleName},
+      {NegatedIfUnless},
+      {PredicateName},
+      {QuotesInString},
+      {Semicolon},
+      {TrailingBlankLines},
+      {TrailingWhitespace},
+      {UnlessElse},
+      {VariableName},
+      {WindowsLineEndings},
+    ]
+  end
+end
 
+
+config :dogma,
+  rule_set: Sqlitex.DogmaRuleSet,
   exclude: [
     ~r(\Atest/test_database.exs),
-  ],
-  additional_config: [
-    LineLength: [max_length: 100]
   ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,9 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "dogma": {:hex, :dogma, "0.0.7"},
+  "dialyze": {:hex, :dialyze, "0.2.0"},
+  "dogma": {:hex, :dogma, "0.0.9"},
   "earmark": {:hex, :earmark, "0.1.17"},
   "esqlite": {:hex, :esqlite, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.9.0"},
+  "ex_doc": {:hex, :ex_doc, "0.10.0"},
   "inch_ex": {:hex, :inch_ex, "0.4.0"},
   "pipe": {:hex, :pipe, "0.0.2"},
   "poison": {:hex, :poison, "1.5.0"}}


### PR DESCRIPTION
This updates Dogma to work with elixir `1.1.0` and defines our own RuleSet. Currently we can't configure the line length without just re-defining our own ruleset. The Dogma team is currently working on this: https://github.com/lpil/dogma/issues/70

So in the meantime I just copied and pasted the `Dogma.RuleSet.All` and changed the line length configuration to 100 chars per line.

Ignoring the `test_database.exs` file and set max line length to 100 chars reduces our errors from 289 down to 44 errors.