### PR TITLE
Add esqlite to applications in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Sqlitex.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :esqlite]]
   end
 
   # Type `mix help deps` for more examples and options


### PR DESCRIPTION
This makes building releases of applications using exrm easier - without
this exrm doesn't realise that it needs to package up esqlite into the
release.  This is documented under the first bullet point here:
https://hexdocs.pm/exrm/extra-common-issues.html

It's easily solved by adding `:esqlite` to the application you're
building, but it'd be nice not to have to do that.