### PR TITLE
Row.from fails to parse decimal data types in some cases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,3 @@ elixir:
 after_script:
   - MIX_ENV=dev mix deps.get
   - MIX_ENV=dev mix inch.report
-branches:
-  only:
-    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ elixir:
 after_script:
   - MIX_ENV=dev mix deps.get
   - MIX_ENV=dev mix inch.report
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 otp_release:
  - 18.3
- - 19.0
+ - 19.1
 elixir:
  - 1.2.6
  - 1.3.2

--- a/test/row_test.exs
+++ b/test/row_test.exs
@@ -21,4 +21,10 @@ defmodule Sqlitex.RowTest do
     [row] = from([:datetime],[:test],[{"1988-02-14 15:17:11.123456"}], %{})
     assert %{test: {{1988,2,14},{15,17,11,123_456}}} == row
   end
+
+  test "parses decimal types" do
+    [row] = from([:"DECIMAL(2,1)"], [:cost], [{1}], [])
+    value = Decimal.new(1, 10, -1)
+    assert [{:cost, value}] == row
+  end
 end


### PR DESCRIPTION
I've added a new unit test to `row_test.exs` which explores an issue I've seen trying to bring [sqlite_ecto](https://github.com/jazzyb/sqlite_ecto) up to speed on current Elixir, OTP, and eventually Ecto.

As shown in https://travis-ci.org/scouten/sqlitex/builds/186397549, which targets the branch from this PR, the OTP 18 builds succeed, but the OTP 19 builds fail. FWIW if I run this on my Mac using OTP 19, it succeeds.

I suspect this might be indicative of a larger OTP 19 issue, but wanted to bring this to your attention ASAP.