### PR TITLE
Elixir 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: elixir
 otp_release:
  - 18.3
- - 19.1
+ - 19.2
 elixir:
  - 1.2.6
- - 1.3.2
+ - 1.3.4
+ - 1.4.0
 after_script:
   - MIX_ENV=dev mix deps.get
   - MIX_ENV=dev mix inch.report

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -25,8 +25,8 @@ defmodule Sqlitex.Query do
   @spec query(Sqlitex.connection, String.t | char_list, [bind: [], into: Enum.t]) :: [Enum.t] | Sqlitex.sqlite_error
   def query(db, sql, opts \\ []) do
     with {:ok, stmt} <- Statement.prepare(db, sql),
-         {:ok, stmt} <- Statement.bind_values(stmt, Dict.get(opts, :bind, [])),
-         {:ok, res} <- Statement.fetch_all(stmt, Dict.get(opts, :into, [])),
+         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
+         {:ok, res} <- Statement.fetch_all(stmt, Keyword.get(opts, :into, [])),
     do: {:ok, res}
   end
 
@@ -68,7 +68,7 @@ defmodule Sqlitex.Query do
   @spec query_rows(Sqlitex.connection, String.t | char_list, [bind: []]) :: {:ok, %{}} | Sqlitex.sqlite_error
   def query_rows(db, sql, opts \\ []) do
     with {:ok, stmt} <- Statement.prepare(db, sql),
-         {:ok, stmt} <- Statement.bind_values(stmt, Dict.get(opts, :bind, [])),
+         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
          {:ok, rows} <- Statement.fetch_all(stmt, :raw_list),
     do: {:ok, %{rows: rows, columns: stmt.column_names, types: stmt.column_types}}
   end

--- a/lib/sqlitex/sql_builder.ex
+++ b/lib/sqlitex/sql_builder.ex
@@ -12,8 +12,8 @@ defmodule Sqlitex.SqlBuilder do
   # column_name: :column_type, of
   # column_name: {:column_type, [column_constraints]}
   def create_table(name, table_opts, cols) do
-    tbl_options = get_opts_dict(table_opts, &table_opt/1)
-    get_opt = &(Dict.get(tbl_options, &1, nil))
+    tbl_options = get_opts_map(table_opts, &table_opt/1)
+    get_opt = &(Map.get(tbl_options, &1, nil))
 
     "CREATE #{get_opt.(:temp)} TABLE \"#{name}\" (#{get_columns_block(cols)} #{get_opt.(:primary_key)})"
   end
@@ -38,9 +38,9 @@ defmodule Sqlitex.SqlBuilder do
   defp column_opt(:not_null), do: {:not_null, "NOT NULL"}
   defp column_opt(:autoincrement), do: {:autoincrement, "AUTOINCREMENT"}
 
-  # Helper function that creates a dictionary of option names
+  # Helper function that creates a map of option names
   # and their string representations
-  defp get_opts_dict(opts, opt) do
+  defp get_opts_map(opts, opt) do
     Enum.into(opts, %{}, &(opt.(&1)))
   end
 
@@ -51,8 +51,8 @@ defmodule Sqlitex.SqlBuilder do
       case col do
         # Column with name, type and constraint
         {name, {type, constraints}} ->
-          col_options = get_opts_dict(constraints, &column_opt/1)
-          get_opt = &(Dict.get(col_options, &1, nil))
+          col_options = get_opts_map(constraints, &column_opt/1)
+          get_opt = &(Map.get(col_options, &1, nil))
 
           [~s("#{name}"), type, get_opt.(:primary_key), get_opt.(:not_null), get_opt.(:autoincrement)]
             |> Enum.filter(&(&1))

--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule Sqlitex.Mixfile do
     [app: :sqlitex,
      version: "1.1.0",
      elixir: "~> 1.2",
-     deps: deps,
-     package: package,
+     deps: deps(),
+     package: package(),
      description: """
       A thin Elixir wrapper around esqlite
     """]

--- a/test/order_test.exs
+++ b/test/order_test.exs
@@ -3,7 +3,7 @@ defmodule Sqlitex.OrderTest do
   use ExCheck
 
   property :ordering_query_results do
-    for_all {x, y} in {int, int} do
+    for_all {x, y} in {int(), int()} do
       {:ok, db} = Sqlitex.open(":memory:")
       :ok = Sqlitex.exec(db, "CREATE TABLE t (a INTEGER)")
       :ok = Sqlitex.exec(db, "INSERT INTO t (a) VALUES #{(x..y) |> Enum.map(&( "(#{&1})" )) |> Enum.join(",")}")

--- a/test/sum_test.exs
+++ b/test/sum_test.exs
@@ -3,7 +3,7 @@ defmodule Sqlitex.SumTest do
   use ExCheck
 
   property :sum_integers do
-    for_all nums in such_that(ns in list(int) when length(ns) > 0) do
+    for_all nums in such_that(ns in list(int()) when length(ns) > 0) do
       {:ok, db} = Sqlitex.open(":memory:")
       :ok = Sqlitex.exec(db, "CREATE TABLE t (a INTEGER)")
       Enum.each(nums, fn(num) ->


### PR DESCRIPTION
With the release of Elixir 1.4 this project shows several compile-time warnings. This PR removes these warnings:

* bare-words that resolve to function calls are now deprecated
  * fixed this in `mix.exs` and in the excheck tests for summing and ordering in queries
* Dict is deprecated so I've replaced it will calls to `Map.get/3` and `Keyword.get/3`
  * I think this shouldn't cause any problem because we have documented the expected types that get passed into `Query.query` and `Query.query_rows` as keyword lists. In `SqlBuilder` we use `Enum.into` to create a map, so we just need to use `Map.get/3`

If anyone has a few minutes to review this and make sure I'm not breaking any interfaces that would be very helpful.

/cc @jazzyb @obmarg @scouten 