### PR TITLE
Add prepared statement cache to Sqlitex.Server.

### DIFF
--- a/lib/sqlitex/server/statement_cache.ex
+++ b/lib/sqlitex/server/statement_cache.ex
@@ -1,0 +1,75 @@
+defmodule Sqlitex.Server.StatementCache do
+  @moduledoc """
+  Implements a least-recently used (LRU) cache for prepared SQLite statements.
+
+  Caches a fixed number of prepared statements and purges the statements which
+  were least-recently used when that limit is exceeded.
+  """
+
+  defstruct db: false, size: 0, limit: 1, cached_stmts: %{}, lru: []
+
+  @doc """
+  Creates a new prepared statement cache.
+  """
+  def new({:connection, _, _} = db, limit) when is_integer(limit) and limit > 0 do
+    %__MODULE__{db: db, limit: limit}
+  end
+
+  @doc """
+  Given a statement cache and an SQL statement (string), returns a tuple containing
+  the updated statement cache and a prepared SQL statement.
+
+  If possible, reuses an existing prepared statement; if not, prepares the statement
+  and adds it to the cache, possibly removing the least-recently used prepared
+  statement if the designated cache size limit would be exceeded.
+
+  Will return `{:error, reason}` if SQLite is unable to prepare the statement.
+  """
+  def prepare(%__MODULE__{cached_stmts: cached_stmts} = cache, sql)
+    when is_binary(sql) and byte_size(sql) > 0
+  do
+    case Map.fetch(cached_stmts, sql) do
+      {:ok, stmt} -> {update_cache_for_read(cache, sql), stmt}
+      :error -> prepare_new_statement(cache, sql)
+    end
+  end
+
+  defp prepare_new_statement(%__MODULE__{db: db} = cache, sql) do
+    case Sqlitex.Statement.prepare(db, sql) do
+      {:ok, prepared} ->
+        cache = cache
+          |> store_new_stmt(sql, prepared)
+          |> purge_cache_if_full
+          |> update_cache_for_read(sql)
+
+        {cache, prepared}
+      error -> error
+    end
+  end
+
+  defp store_new_stmt(%__MODULE__{size: size, cached_stmts: cached_stmts} = cache,
+                      sql, prepared)
+  do
+    %{cache | size: size + 1, cached_stmts: Map.put(cached_stmts, sql, prepared)}
+  end
+
+  defp purge_cache_if_full(%__MODULE__{size: size,
+                                       limit: limit,
+                                       cached_stmts: cached_stmts,
+                                       lru: [purge_victim | lru]} = cache)
+    when size > limit
+  do
+    %{cache | size: size - 1,
+              cached_stmts: Map.drop(cached_stmts, [purge_victim]),
+              lru: lru}
+  end
+  defp purge_cache_if_full(cache), do: cache
+
+  defp update_cache_for_read(%__MODULE__{lru: lru} = cache, sql) do
+    lru = lru
+      |> Enum.reject(&(&1 == sql))
+      |> Kernel.++([sql])
+
+    %{cache | lru: lru}
+  end
+end

--- a/test/server/statement_cache_test.exs
+++ b/test/server/statement_cache_test.exs
@@ -1,0 +1,40 @@
+defmodule Sqlitex.Server.StatementCacheTest do
+  use ExUnit.Case
+
+  alias Sqlitex.Server.StatementCache, as: S
+  alias Sqlitex.Statement, as: Stmt
+
+  test "basic happy path" do
+    {:ok, db} = Sqlitex.open(":memory:")
+
+    cache = S.new(db, 3)
+    assert %S{cached_stmts: %{}, db: _, limit: 3, lru: [], size: 0} = cache
+
+
+    {cache, stmt1a} = S.prepare(cache, "SELECT 42")
+    assert %Stmt{column_names: [:"42"], column_types: [nil], statement: ""} = stmt1a
+
+    {cache, stmt2a} = S.prepare(cache, "SELECT 43")
+    assert %Stmt{column_names: [:"43"], column_types: [nil], statement: ""} = stmt2a
+
+    {cache, stmt3} = S.prepare(cache, "SELECT 44")
+    assert %Stmt{column_names: [:"44"], column_types: [nil], statement: ""} = stmt3
+
+    {cache, stmt1b} = S.prepare(cache, "SELECT 42")
+    assert stmt1a == stmt1b # shouldn't have been purged
+
+    {cache, stmt4} = S.prepare(cache, "SELECT 353")
+    assert %Stmt{column_names: [:"353"], column_types: [nil], statement: ""} = stmt4
+
+    {_cache, stmt2b} = S.prepare(cache, "SELECT 42")
+    refute stmt2a == stmt2b # should have been purged
+  end
+
+  test "relays error in prepare" do
+    {:ok, db} = Sqlitex.open(":memory:")
+    cache = S.new(db, 3)
+
+    assert {:error, {:sqlite_error, 'near "bogus": syntax error'}}
+      = S.prepare(cache, "bogus")
+  end
+end


### PR DESCRIPTION
Also adds a new function call `prepare` which prepares the SQL statement, adds it to the cache, and returns information about the query to the calling process. To protect encapsulation across processes, it does not return any direct reference to the prepared statement itself.