### PR TITLE
Implement returning clause support.

### DIFF
--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -350,14 +350,12 @@ defmodule Sqlitex.Statement do
   end
 
   defp safe_call(db, func, sp) do
-    try do
-      func.()
-    rescue
-      e in RuntimeError ->
-        [] = :esqlite3.q("ROLLBACK TO SAVEPOINT #{sp}", db)
-        [] = :esqlite3.q("RELEASE #{sp}", db)
-        raise e
-    end
+    func.()
+  catch
+    e in RuntimeError ->
+      [] = :esqlite3.q("ROLLBACK TO SAVEPOINT #{sp}", db)
+      [] = :esqlite3.q("RELEASE #{sp}", db)
+      raise e
   end
 
   defp with_temp_table(db, returning, func) do

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -34,7 +34,7 @@ defmodule Sqlitex.Statement do
   commands. (See https://www.postgresql.org/docs/9.6/static/sql-insert.html for
   a description of the Postgres implementation of this clause.)
 
-  Ecto 2.0 relies on being able to capture this information, so have invented our
+  Ecto 2.0+ relies on being able to capture this information, so have invented our
   own implementation with the following syntax:
 
   ```

--- a/test/statement_test.exs
+++ b/test/statement_test.exs
@@ -12,53 +12,51 @@ defmodule StatementTest do
     assert result == [[user_version: 0]]
   end
 
-  describe "RETURNING pseudo-syntax" do
-    test "returns id from a single row insert" do
-      {:ok, db} = Sqlitex.open(":memory:")
+  test "RETURNING pseudo-syntax returns id from a single row insert" do
+    {:ok, db} = Sqlitex.open(":memory:")
 
-      Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
+    Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
 
-      stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES (?1) "
-                                            <> ";--RETURNING ON INSERT x,id")
+    stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES (?1) "
+                                          <> ";--RETURNING ON INSERT x,id")
 
-      rows = Sqlitex.Statement.fetch_all!(stmt)
-      assert rows == [[id: 1]]
-    end
+    rows = Sqlitex.Statement.fetch_all!(stmt)
+    assert rows == [[id: 1]]
+  end
 
-    test "returns id from a single row insert as a raw list" do
-      {:ok, db} = Sqlitex.open(":memory:")
+  test "RETURNING pseudo-syntax returns id from a single row insert as a raw list" do
+    {:ok, db} = Sqlitex.open(":memory:")
 
-      Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
+    Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
 
-      stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES (?1) "
-                                            <> ";--RETURNING ON INSERT x,id")
+    stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES (?1) "
+                                          <> ";--RETURNING ON INSERT x,id")
 
-      rows = Sqlitex.Statement.fetch_all!(stmt, :raw_list)
-      assert rows == [[1]]
-    end
+    rows = Sqlitex.Statement.fetch_all!(stmt, :raw_list)
+    assert rows == [[1]]
+  end
 
-    test "returns id from a multi-row insert" do
-      {:ok, db} = Sqlitex.open(":memory:")
+  test "RETURNING pseudo-syntax returns id from a multi-row insert" do
+    {:ok, db} = Sqlitex.open(":memory:")
 
-      Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
+    Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
 
-      stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES ('x'),('y'),('z') "
-                                            <> ";--RETURNING ON INSERT x,id")
+    stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES ('x'),('y'),('z') "
+                                          <> ";--RETURNING ON INSERT x,id")
 
-      rows = Sqlitex.Statement.fetch_all!(stmt)
-      assert rows == [[id: 1], [id: 2], [id: 3]]
-    end
+    rows = Sqlitex.Statement.fetch_all!(stmt)
+    assert rows == [[id: 1], [id: 2], [id: 3]]
+  end
 
-    test "returns id from a multi-row insert as a raw list" do
-      {:ok, db} = Sqlitex.open(":memory:")
+  test "RETURNING pseudo-syntax returns id from a multi-row insert as a raw list" do
+    {:ok, db} = Sqlitex.open(":memory:")
 
-      Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
+    Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
 
-      stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES ('x'),('y'),('z') "
-                                            <> ";--RETURNING ON INSERT x,id")
+    stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES ('x'),('y'),('z') "
+                                          <> ";--RETURNING ON INSERT x,id")
 
-      rows = Sqlitex.Statement.fetch_all!(stmt, :raw_list)
-      assert rows == [[1], [2], [3]]
-    end
+    rows = Sqlitex.Statement.fetch_all!(stmt, :raw_list)
+    assert rows == [[1], [2], [3]]
   end
 end

--- a/test/statement_test.exs
+++ b/test/statement_test.exs
@@ -11,4 +11,54 @@ defmodule StatementTest do
 
     assert result == [[user_version: 0]]
   end
+
+  describe "RETURNING pseudo-syntax" do
+    test "returns id from a single row insert" do
+      {:ok, db} = Sqlitex.open(":memory:")
+
+      Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
+
+      stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES (?1) "
+                                            <> ";--RETURNING ON INSERT x,id")
+
+      rows = Sqlitex.Statement.fetch_all!(stmt)
+      assert rows == [[id: 1]]
+    end
+
+    test "returns id from a single row insert as a raw list" do
+      {:ok, db} = Sqlitex.open(":memory:")
+
+      Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
+
+      stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES (?1) "
+                                            <> ";--RETURNING ON INSERT x,id")
+
+      rows = Sqlitex.Statement.fetch_all!(stmt, :raw_list)
+      assert rows == [[1]]
+    end
+
+    test "returns id from a multi-row insert" do
+      {:ok, db} = Sqlitex.open(":memory:")
+
+      Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
+
+      stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES ('x'),('y'),('z') "
+                                            <> ";--RETURNING ON INSERT x,id")
+
+      rows = Sqlitex.Statement.fetch_all!(stmt)
+      assert rows == [[id: 1], [id: 2], [id: 3]]
+    end
+
+    test "returns id from a multi-row insert as a raw list" do
+      {:ok, db} = Sqlitex.open(":memory:")
+
+      Sqlitex.exec(db, "CREATE TABLE x(id INTEGER PRIMARY KEY AUTOINCREMENT, str)")
+
+      stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES ('x'),('y'),('z') "
+                                            <> ";--RETURNING ON INSERT x,id")
+
+      rows = Sqlitex.Statement.fetch_all!(stmt, :raw_list)
+      assert rows == [[1], [2], [3]]
+    end
+  end
 end


### PR DESCRIPTION
Ecto often requires the ability to return auto-generated values from INSERT and UPDATE statements (consider row IDs for newly-inserted content as an example). This isn't directly supported by SQLite (unlike, for example, Postgres), but can be implemented by adding temporary triggers.

In Ecto 1.x (and corresponding jazzyb/sqlite_ecto), the access to SQLite was synchronous so the SQLite Ecto adapter could add and remove the triggers as it needed.

In Ecto 2.x (and scouten/sqlite_ecto2 that is nearing its initial release), we now use Sqlitex.Server so adding and removing temporary triggers is not feasible from external code because (rightly so) the Sqlitex.Server code is self-contained.

This patch ports the returning clause support from jazzyb/sqlite_ecto into Sqlitex.Server.