### PR TITLE
Relax requirement on :decimal library.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Sqlitex.Mixfile do
   defp deps do
     [
       {:esqlite, "~> 0.2.0"},
-      {:decimal, "~> 1.1.0"},
+      {:decimal, "~> 1.1"},
 
       {:credo, "~> 0.4", only: :dev},
       {:dialyze, "~> 0.2.0", only: :dev},


### PR DESCRIPTION
Without this change, sqlitex can not be by a Hex package that also uses Ecto 2.1.4.

```
sqlite_ecto2 scouten$ mix hex.publish
** (Mix) Can't build package with overridden dependency decimal, remove `override: true`

# (edit sqlite_ecto2 mix.exs file to remove override: true on decimal)

sqlite_ecto2 scouten$ mix deps.unlock decimal
sqlite_ecto2 scouten$ mix deps.get
Running dependency resolution...

Failed to use "decimal" (versions 1.1.0 to 1.1.2) because
  ecto (version 2.1.4) requires ~> 1.2
  postgrex (version 0.13.0) requires ~> 1.0
  sqlitex (version 1.3.0) requires ~> 1.1.0
  mix.exs specifies ~> 1.1


Failed to use "decimal" (versions 1.2.0 to 1.3.1) because
  sqlitex (version 1.3.0) requires ~> 1.1.0
  mix.exs specifies ~> 1.1

** (Mix) Hex dependency resolution failed, relax the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you are unable to resolve the conflicts you can try overriding with {:dependency, "~> 1.0", override: true}
```