### PR TITLE
Get rid of warnings when compiling under 1.5.x #60

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ elixir:
  - 1.2.6
  - 1.3.4
  - 1.4.0
+ - 1.5.1
+matrix:
+  include:
+    - elixir: 1.5.1
+      otp_release: 20.0
 after_script:
   - MIX_ENV=dev mix deps.get
   - MIX_ENV=dev mix inch.report

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -1,7 +1,11 @@
 defmodule Sqlitex do
+  if Version.compare(System.version, "1.3.0") == :lt do
+    @type charlist :: char_list
+  end
+
   @type connection :: {:connection, reference, String.t}
-  @type string_or_charlist :: String.t | char_list
-  @type sqlite_error :: {:error, {:sqlite_error, char_list}}
+  @type string_or_charlist :: String.t | charlist
+  @type sqlite_error :: {:error, {:sqlite_error, charlist}}
 
   @moduledoc """
   Sqlitex gives you a way to create and query sqlite databases.
@@ -28,8 +32,8 @@ defmodule Sqlitex do
   end
 
   @spec open(String.t) :: {:ok, connection}
-  @spec open(char_list) :: {:ok, connection} | {:error, {atom, char_list}}
-  def open(path) when is_binary(path), do: open(String.to_char_list(path))
+  @spec open(charlist) :: {:ok, connection} | {:error, {atom, charlist}}
+  def open(path) when is_binary(path), do: open(string_to_charlist(path))
   def open(path) do
     :esqlite3.open(path)
   end
@@ -73,4 +77,10 @@ defmodule Sqlitex do
     stmt = Sqlitex.SqlBuilder.create_table(name, table_opts, cols)
     exec(db, stmt)
   end
+
+ if Version.compare(System.version, "1.3.0") == :lt do
+   defp string_to_charlist(string), do: String.to_char_list(string)
+ else
+   defp string_to_charlist(string), do: String.to_charlist(string)
+ end
 end

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -21,8 +21,12 @@ defmodule Sqlitex.Query do
   * {:error, _} on failure.
   """
 
-  @spec query(Sqlitex.connection, String.t | char_list) :: [[]] | Sqlitex.sqlite_error
-  @spec query(Sqlitex.connection, String.t | char_list, [bind: [], into: Enum.t]) :: [Enum.t] | Sqlitex.sqlite_error
+  if Version.compare(System.version, "1.3.0") == :lt do
+    @type charlist :: char_list
+  end
+
+  @spec query(Sqlitex.connection, String.t | charlist) :: [[]] | Sqlitex.sqlite_error
+  @spec query(Sqlitex.connection, String.t | charlist, [bind: [], into: Enum.t]) :: [Enum.t] | Sqlitex.sqlite_error
   def query(db, sql, opts \\ []) do
     with {:ok, stmt} <- Statement.prepare(db, sql),
          {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
@@ -35,8 +39,8 @@ defmodule Sqlitex.Query do
 
   Returns the results otherwise.
   """
-  @spec query!(Sqlitex.connection, String.t | char_list) :: [[]]
-  @spec query!(Sqlitex.connection, String.t | char_list, [bind: [], into: Enum.t]) :: [Enum.t]
+  @spec query!(Sqlitex.connection, String.t | charlist) :: [[]]
+  @spec query!(Sqlitex.connection, String.t | charlist, [bind: [], into: Enum.t]) :: [Enum.t]
   def query!(db, sql, opts \\ []) do
     case query(db, sql, opts) do
       {:error, reason} -> raise Sqlitex.QueryError, reason: reason
@@ -64,8 +68,8 @@ defmodule Sqlitex.Query do
   * {:error, _} on failure.
   """
 
-  @spec query_rows(Sqlitex.connection, String.t | char_list) :: {:ok, %{}} | Sqlitex.sqlite_error
-  @spec query_rows(Sqlitex.connection, String.t | char_list, [bind: []]) :: {:ok, %{}} | Sqlitex.sqlite_error
+  @spec query_rows(Sqlitex.connection, String.t | charlist) :: {:ok, %{}} | Sqlitex.sqlite_error
+  @spec query_rows(Sqlitex.connection, String.t | charlist, [bind: []]) :: {:ok, %{}} | Sqlitex.sqlite_error
   def query_rows(db, sql, opts \\ []) do
     with {:ok, stmt} <- Statement.prepare(db, sql),
          {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
@@ -78,8 +82,8 @@ defmodule Sqlitex.Query do
 
   Returns the results otherwise.
   """
-  @spec query_rows!(Sqlitex.connection, String.t | char_list) :: [[]]
-  @spec query_rows!(Sqlitex.connection, String.t | char_list, [bind: []]) :: [Enum.t]
+  @spec query_rows!(Sqlitex.connection, String.t | charlist) :: [[]]
+  @spec query_rows!(Sqlitex.connection, String.t | charlist, [bind: []]) :: [Enum.t]
   def query_rows!(db, sql, opts \\ []) do
     case query_rows(db, sql, opts) do
       {:error, reason} -> raise Sqlitex.QueryError, reason: reason

--- a/lib/sqlitex/row.ex
+++ b/lib/sqlitex/row.ex
@@ -53,7 +53,7 @@ defmodule Sqlitex.Row do
   end
   defp translate_value({float, "decimal"}), do: Decimal.new(float)
   defp translate_value({float, "decimal(" <> rest}) do
-    [precision, scale] = rest |> String.rstrip(?)) |> String.split(",") |> Enum.map(&String.to_integer/1)
+    [precision, scale] = rest |> string_rstrip(?)) |> String.split(",") |> Enum.map(&String.to_integer/1)
     Decimal.with_context %Decimal.Context{precision: precision, rounding: :down}, fn ->
       float |> Float.round(scale) |> Decimal.new |> Decimal.plus
     end
@@ -77,5 +77,11 @@ defmodule Sqlitex.Row do
   defp to_time(<<hr::binary-size(2), ":", mi::binary-size(2), ":", se::binary-size(2), ".", fr::binary>>) when byte_size(fr) <= 6 do
     fr = String.to_integer(fr <> String.duplicate("0", 6 - String.length(fr)))
     {String.to_integer(hr), String.to_integer(mi), String.to_integer(se), fr}
+  end
+
+  if Version.compare(System.version, "1.5.0") == :lt do
+    defp string_rstrip(string, char), do: String.rstrip(string, char)
+  else
+    defp string_rstrip(string, char), do: String.trim_trailing(string, to_string([char]))
   end
 end


### PR DESCRIPTION
These changes quiet the warnings emitted when compiling under Elixir
1.5.1, they also work under 1.4.4.

This addresses my issue https://github.com/mmmries/sqlitex/issues/60
but I'm not sure if it's the "right thing" to do. That depends on how much
testing you want to do with older Elixirs.