### PR TITLE
Deps and typespecs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,4 +2,6 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :excheck, :number_iterations, 100
+if Mix.env == :test do
+  config :excheck, :number_iterations, 100
+end

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -31,8 +31,7 @@ defmodule Sqlitex do
     :esqlite3.close(db)
   end
 
-  @spec open(String.t) :: {:ok, connection}
-  @spec open(charlist) :: {:ok, connection} | {:error, {atom, charlist}}
+  @spec open(charlist | String.t) :: {:ok, connection} | {:error, {atom, charlist}}
   def open(path) when is_binary(path), do: open(string_to_charlist(path))
   def open(path) do
     :esqlite3.open(path)

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -3,7 +3,7 @@ defmodule Sqlitex do
     @type charlist :: char_list
   end
 
-  @type connection :: {:connection, reference, String.t}
+  @type connection :: {:connection, reference, binary()}
   @type string_or_charlist :: String.t | charlist
   @type sqlite_error :: {:error, {:sqlite_error, charlist}}
 

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -26,7 +26,7 @@ defmodule Sqlitex.Query do
   end
 
   @spec query(Sqlitex.connection, String.t | charlist) :: {:ok, [[]]} | {:error, term()}
-  @spec query(Sqlitex.connection, String.t | charlist, keyword) :: {:ok, [[]]} | {:error, term()}
+  @spec query(Sqlitex.connection, String.t | charlist, [{atom, term}]) :: {:ok, [[]]} | {:error, term()}
   def query(db, sql, opts \\ []) do
     with {:ok, stmt} <- Statement.prepare(db, sql),
          {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -25,8 +25,8 @@ defmodule Sqlitex.Query do
     @type charlist :: char_list
   end
 
-  @spec query(Sqlitex.connection, String.t | charlist) :: [[]] | Sqlitex.sqlite_error
-  @spec query(Sqlitex.connection, String.t | charlist, [bind: [], into: Enum.t]) :: [Enum.t] | Sqlitex.sqlite_error
+  @spec query(Sqlitex.connection, String.t | charlist) :: {:ok, [[]]} | {:error, term()}
+  @spec query(Sqlitex.connection, String.t | charlist, keyword) :: {:ok, [[]]} | {:error, term()}
   def query(db, sql, opts \\ []) do
     with {:ok, stmt} <- Statement.prepare(db, sql),
          {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
@@ -82,8 +82,8 @@ defmodule Sqlitex.Query do
 
   Returns the results otherwise.
   """
-  @spec query_rows!(Sqlitex.connection, String.t | charlist) :: [[]]
-  @spec query_rows!(Sqlitex.connection, String.t | charlist, [bind: []]) :: [Enum.t]
+  @spec query_rows!(Sqlitex.connection, String.t | charlist) :: %{}
+  @spec query_rows!(Sqlitex.connection, String.t | charlist, [bind: []]) :: %{}
   def query_rows!(db, sql, opts \\ []) do
     case query_rows(db, sql, opts) do
       {:error, reason} -> raise Sqlitex.QueryError, reason: reason

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -366,6 +366,7 @@ defmodule Sqlitex.Statement do
     {:ok, _} = db_exec(db, "RELEASE #{sp}")
   end
 
+  @spec db_exec(Sqlitex.connection, iodata()) :: {:ok, [tuple()]}
   defp db_exec(db, sql) do
     case :esqlite3.q(sql, db) do
       {:error, _} = error ->

--- a/mix.exs
+++ b/mix.exs
@@ -30,12 +30,10 @@ defmodule Sqlitex.Mixfile do
       {:decimal, "~> 1.1"},
 
       {:credo, "~> 0.4", only: :dev},
-      {:dialyze, "~> 0.2.0", only: :dev},
-      {:earmark, "1.0.3", only: :dev},
-        # v1.1 introduces a deprecation warning that causes a lot of console
-        # noise when used with current as-of-this-writing version of exdoc (0.14.5)
+      {:dialyxir, "~> 0.5.1", only: :dev, runtime: false},
+      {:earmark, "~> 1.2", only: :dev},
       {:excoveralls, "~> 0.6", only: :test},
-      {:ex_doc, "~> 0.14.5", only: :dev},
+      {:ex_doc, "~> 0.18", only: :dev},
       {:inch_ex, "~> 0.5", only: :dev},
 
       {:excheck, "~> 0.5", only: :test},


### PR DESCRIPTION
I was doing some experiments with `dialyxir` and found that the dependencies in this project (dev dependencies) were a bit out of date, and that we had some typespec errors.

Some of these dialyzer warnings were form [incorrect type specs in esqlite](https://github.com/mmzeeman/esqlite/pull/37). But some of them were just our own mistakes. Building against my branch of esqlite is now clean of errors.