### PR TITLE
run Travis builds on recent OTP and Elixir Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: elixir
 otp_release:
- - 18.3
- - 19.2
+ - 20.1
+ - 20.2
+ - 20.3
 elixir:
- - 1.2.6
- - 1.3.4
- - 1.4.0
- - 1.5.1
-matrix:
-  include:
-    - elixir: 1.5.1
-      otp_release: 20.0
+ - 1.4.5
+ - 1.5.3
+ - 1.6.4
 after_script:
   - MIX_ENV=dev mix deps.get
   - MIX_ENV=dev mix inch.report


### PR DESCRIPTION
This is just an update to run out Travis builds against the recent version of Elixir and OTP.