### PR TITLE
Allow esqlite’s timeout to be specified

### DIFF
--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -24,29 +24,46 @@ defmodule Sqlitex do
   {:ok, [%{a: 1, b: 2, c: 3}]}
 
   ```
+
+  ## Configuration
+
+  Sqlitex uses the Erlang library [esqlite](https://github.com/mmzeeman/esqlite)
+  which accepts a timeout parameter for almost all interactions with the database.
+  The default value for this timeout is 5000 ms. Many functions in Sqlitex accept
+  a timeout parameter that is passed on to the esqlite calls and that also defaults
+  to 5000 ms. If required, this default value can be overridden globally with the
+  following in your `config.exs`:
+
+  ```
+  config :sqlitex,
+    esqlite3_timeout: 10_000 # or other positive integer number of ms
+  ```
   """
 
-  @spec close(connection) :: :ok
-  def close(db) do
-    :esqlite3.close(db)
+  @esqlite3_timeout Application.get_env(:sqlitex, :esqlite3_timeout, 5_000)
+
+  @spec close(connection, integer()) :: :ok
+  def close(db, timeout \\ @esqlite3_timeout) do
+    :esqlite3.close(db, timeout)
   end
 
-  @spec open(charlist | String.t) :: {:ok, connection} | {:error, {atom, charlist}}
-  def open(path) when is_binary(path), do: open(string_to_charlist(path))
-  def open(path) do
-    :esqlite3.open(path)
+  @spec open(charlist | String.t, integer()) :: {:ok, connection} | {:error, {atom, charlist}}
+  def open(path, timeout \\ @esqlite3_timeout)
+  def open(path, timeout) when is_binary(path), do: open(string_to_charlist(path), timeout)
+  def open(path, timeout) do
+    :esqlite3.open(path, timeout)
   end
 
-  def with_db(path, fun) do
-    {:ok, db} = open(path)
+  def with_db(path, fun, timeout \\ @esqlite3_timeout) do
+    {:ok, db} = open(path, timeout)
     res = fun.(db)
-    close(db)
+    close(db, timeout)
     res
   end
 
-  @spec exec(connection, string_or_charlist) :: :ok | sqlite_error
-  def exec(db, sql) do
-    :esqlite3.exec(sql, db)
+  @spec exec(connection, string_or_charlist, integer()) :: :ok | sqlite_error
+  def exec(db, sql, timeout \\ @esqlite3_timeout) do
+    :esqlite3.exec(sql, db, timeout)
   end
 
   def query(db, sql, opts \\ []), do: Sqlitex.Query.query(db, sql, opts)
@@ -72,9 +89,9 @@ defmodule Sqlitex do
   **id: :integer, name: {:text, [:not_null]}**
 
   """
-  def create_table(db, name, table_opts \\ [], cols) do
+  def create_table(db, name, table_opts \\ [], cols, timeout \\ @esqlite3_timeout) do
     stmt = Sqlitex.SqlBuilder.create_table(name, table_opts, cols)
-    exec(db, stmt)
+    exec(db, stmt, timeout)
   end
 
  if Version.compare(System.version, "1.3.0") == :lt do

--- a/lib/sqlitex/config.ex
+++ b/lib/sqlitex/config.ex
@@ -1,0 +1,9 @@
+defmodule Sqlitex.Config do
+  @moduledoc false
+
+  def esqlite3_timeout do
+    Application.get_env(:sqlitex, :esqlite3_timeout, default_esqlite3_timeout())
+  end
+
+  def default_esqlite3_timeout, do: 5_000
+end

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -15,6 +15,8 @@ defmodule Sqlitex.Query do
   * `bind` - If your query has parameters in it, you should provide the options
     to bind as a list.
   * `into` - The collection to put results into.  This defaults to a list.
+  * `timeout` - The timeout (in ms) to apply to each of the underlying SQLite operations. Defaults
+    to 5000, or to `Application.get_env(:sqlitex, :esqlite3_timeout)` if set.
 
   ## Returns
   * [results...] on success
@@ -28,10 +30,7 @@ defmodule Sqlitex.Query do
   @spec query(Sqlitex.connection, String.t | charlist) :: {:ok, [[]]} | {:error, term()}
   @spec query(Sqlitex.connection, String.t | charlist, [{atom, term}]) :: {:ok, [[]]} | {:error, term()}
   def query(db, sql, opts \\ []) do
-    with {:ok, stmt} <- Statement.prepare(db, sql),
-         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
-         {:ok, res} <- Statement.fetch_all(stmt, Keyword.get(opts, :into, [])),
-    do: {:ok, res}
+    do_query(db, sql, opts, Keyword.get(opts, :timeout, nil))
   end
 
   @doc """
@@ -40,12 +39,25 @@ defmodule Sqlitex.Query do
   Returns the results otherwise.
   """
   @spec query!(Sqlitex.connection, String.t | charlist) :: [[]]
-  @spec query!(Sqlitex.connection, String.t | charlist, [bind: [], into: Enum.t]) :: [Enum.t]
+  @spec query!(Sqlitex.connection, String.t | charlist, [bind: [], into: Enum.t, timeout: integer()]) :: [Enum.t]
   def query!(db, sql, opts \\ []) do
     case query(db, sql, opts) do
       {:error, reason} -> raise Sqlitex.QueryError, reason: reason
       {:ok, results} -> results
     end
+  end
+
+  defp do_query(db, sql, opts, nil) do
+    with {:ok, stmt} <- Statement.prepare(db, sql),
+         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
+         {:ok, res} <- Statement.fetch_all(stmt, Keyword.get(opts, :into, [])),
+    do: {:ok, res}
+  end
+  defp do_query(db, sql, opts, timeout) do
+    with {:ok, stmt} <- Statement.prepare(db, sql, timeout),
+         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), timeout),
+         {:ok, res} <- Statement.fetch_all(stmt, Keyword.get(opts, :into, [])),
+    do: {:ok, res}
   end
 
   @doc """
@@ -62,6 +74,8 @@ defmodule Sqlitex.Query do
 
   * `bind` - If your query has parameters in it, you should provide the options
     to bind as a list.
+  * `timeout` - The timeout (in ms) to apply to each of the underlying SQLite operations. Defaults
+    to 5000, or to `Application.get_env(:sqlitex, :esqlite3_timeout)` if set.
 
   ## Returns
   * {:ok, %{rows: [[1, 2], [2, 3]], columns: [:a, :b], types: [:INTEGER, :INTEGER]}} on success
@@ -69,12 +83,9 @@ defmodule Sqlitex.Query do
   """
 
   @spec query_rows(Sqlitex.connection, String.t | charlist) :: {:ok, %{}} | Sqlitex.sqlite_error
-  @spec query_rows(Sqlitex.connection, String.t | charlist, [bind: []]) :: {:ok, %{}} | Sqlitex.sqlite_error
+  @spec query_rows(Sqlitex.connection, String.t | charlist, [bind: [], timeout: integer()]) :: {:ok, %{}} | Sqlitex.sqlite_error
   def query_rows(db, sql, opts \\ []) do
-    with {:ok, stmt} <- Statement.prepare(db, sql),
-         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
-         {:ok, rows} <- Statement.fetch_all(stmt, :raw_list),
-    do: {:ok, %{rows: rows, columns: stmt.column_names, types: stmt.column_types}}
+    do_query_rows(db, sql, opts, Keyword.get(opts, :timeout, nil))
   end
 
   @doc """
@@ -83,11 +94,24 @@ defmodule Sqlitex.Query do
   Returns the results otherwise.
   """
   @spec query_rows!(Sqlitex.connection, String.t | charlist) :: %{}
-  @spec query_rows!(Sqlitex.connection, String.t | charlist, [bind: []]) :: %{}
+  @spec query_rows!(Sqlitex.connection, String.t | charlist, [bind: [], timeout: integer()]) :: %{}
   def query_rows!(db, sql, opts \\ []) do
     case query_rows(db, sql, opts) do
       {:error, reason} -> raise Sqlitex.QueryError, reason: reason
       {:ok, results} -> results
     end
+  end
+
+  defp do_query_rows(db, sql, opts, nil) do
+    with {:ok, stmt} <- Statement.prepare(db, sql),
+         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
+         {:ok, rows} <- Statement.fetch_all(stmt, :raw_list),
+    do: {:ok, %{rows: rows, columns: stmt.column_names, types: stmt.column_types}}
+  end
+  defp do_query_rows(db, sql, opts, timeout) do
+    with {:ok, stmt} <- Statement.prepare(db, sql, timeout),
+         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), timeout),
+         {:ok, rows} <- Statement.fetch_all(stmt, :raw_list),
+    do: {:ok, %{rows: rows, columns: stmt.column_names, types: stmt.column_types}}
   end
 end

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -15,7 +15,7 @@ defmodule Sqlitex.Query do
   * `bind` - If your query has parameters in it, you should provide the options
     to bind as a list.
   * `into` - The collection to put results into.  This defaults to a list.
-  * `timeout` - The timeout (in ms) to apply to each of the underlying SQLite operations. Defaults
+  * `db_timeout` - The timeout (in ms) to apply to each of the underlying SQLite operations. Defaults
     to 5000, or to `Application.get_env(:sqlitex, :esqlite3_timeout)` if set.
 
   ## Returns
@@ -30,7 +30,10 @@ defmodule Sqlitex.Query do
   @spec query(Sqlitex.connection, String.t | charlist) :: {:ok, [[]]} | {:error, term()}
   @spec query(Sqlitex.connection, String.t | charlist, [{atom, term}]) :: {:ok, [[]]} | {:error, term()}
   def query(db, sql, opts \\ []) do
-    do_query(db, sql, opts, Keyword.get(opts, :timeout, nil))
+    with {:ok, stmt} <- Statement.prepare(db, sql, opts),
+         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), opts),
+         {:ok, res} <- Statement.fetch_all(stmt, Keyword.get(opts, :into, [])),
+    do: {:ok, res}
   end
 
   @doc """
@@ -39,25 +42,12 @@ defmodule Sqlitex.Query do
   Returns the results otherwise.
   """
   @spec query!(Sqlitex.connection, String.t | charlist) :: [[]]
-  @spec query!(Sqlitex.connection, String.t | charlist, [bind: [], into: Enum.t, timeout: integer()]) :: [Enum.t]
+  @spec query!(Sqlitex.connection, String.t | charlist, [bind: [], into: Enum.t, db_timeout: integer()]) :: [Enum.t]
   def query!(db, sql, opts \\ []) do
     case query(db, sql, opts) do
       {:error, reason} -> raise Sqlitex.QueryError, reason: reason
       {:ok, results} -> results
     end
-  end
-
-  defp do_query(db, sql, opts, nil) do
-    with {:ok, stmt} <- Statement.prepare(db, sql),
-         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
-         {:ok, res} <- Statement.fetch_all(stmt, Keyword.get(opts, :into, [])),
-    do: {:ok, res}
-  end
-  defp do_query(db, sql, opts, timeout) do
-    with {:ok, stmt} <- Statement.prepare(db, sql, timeout),
-         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), timeout),
-         {:ok, res} <- Statement.fetch_all(stmt, Keyword.get(opts, :into, [])),
-    do: {:ok, res}
   end
 
   @doc """
@@ -74,7 +64,7 @@ defmodule Sqlitex.Query do
 
   * `bind` - If your query has parameters in it, you should provide the options
     to bind as a list.
-  * `timeout` - The timeout (in ms) to apply to each of the underlying SQLite operations. Defaults
+  * `db_timeout` - The timeout (in ms) to apply to each of the underlying SQLite operations. Defaults
     to 5000, or to `Application.get_env(:sqlitex, :esqlite3_timeout)` if set.
 
   ## Returns
@@ -83,9 +73,12 @@ defmodule Sqlitex.Query do
   """
 
   @spec query_rows(Sqlitex.connection, String.t | charlist) :: {:ok, %{}} | Sqlitex.sqlite_error
-  @spec query_rows(Sqlitex.connection, String.t | charlist, [bind: [], timeout: integer()]) :: {:ok, %{}} | Sqlitex.sqlite_error
+  @spec query_rows(Sqlitex.connection, String.t | charlist, [bind: [], db_timeout: integer()]) :: {:ok, %{}} | Sqlitex.sqlite_error
   def query_rows(db, sql, opts \\ []) do
-    do_query_rows(db, sql, opts, Keyword.get(opts, :timeout, nil))
+    with {:ok, stmt} <- Statement.prepare(db, sql, opts),
+         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), opts),
+         {:ok, rows} <- Statement.fetch_all(stmt, :raw_list),
+    do: {:ok, %{rows: rows, columns: stmt.column_names, types: stmt.column_types}}
   end
 
   @doc """
@@ -94,24 +87,11 @@ defmodule Sqlitex.Query do
   Returns the results otherwise.
   """
   @spec query_rows!(Sqlitex.connection, String.t | charlist) :: %{}
-  @spec query_rows!(Sqlitex.connection, String.t | charlist, [bind: [], timeout: integer()]) :: %{}
+  @spec query_rows!(Sqlitex.connection, String.t | charlist, [bind: [], db_timeout: integer()]) :: %{}
   def query_rows!(db, sql, opts \\ []) do
     case query_rows(db, sql, opts) do
       {:error, reason} -> raise Sqlitex.QueryError, reason: reason
       {:ok, results} -> results
     end
-  end
-
-  defp do_query_rows(db, sql, opts, nil) do
-    with {:ok, stmt} <- Statement.prepare(db, sql),
-         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, [])),
-         {:ok, rows} <- Statement.fetch_all(stmt, :raw_list),
-    do: {:ok, %{rows: rows, columns: stmt.column_names, types: stmt.column_types}}
-  end
-  defp do_query_rows(db, sql, opts, timeout) do
-    with {:ok, stmt} <- Statement.prepare(db, sql, timeout),
-         {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), timeout),
-         {:ok, rows} <- Statement.fetch_all(stmt, :raw_list),
-    do: {:ok, %{rows: rows, columns: stmt.column_names, types: stmt.column_types}}
   end
 end

--- a/lib/sqlitex/server/statement_cache.ex
+++ b/lib/sqlitex/server/statement_cache.ex
@@ -25,17 +25,17 @@ defmodule Sqlitex.Server.StatementCache do
 
   Will return `{:error, reason}` if SQLite is unable to prepare the statement.
   """
-  def prepare(%__MODULE__{cached_stmts: cached_stmts} = cache, sql)
+  def prepare(%__MODULE__{cached_stmts: cached_stmts} = cache, sql, timeout)
     when is_binary(sql) and byte_size(sql) > 0
   do
     case Map.fetch(cached_stmts, sql) do
       {:ok, stmt} -> {update_cache_for_read(cache, sql), stmt}
-      :error -> prepare_new_statement(cache, sql)
+      :error -> prepare_new_statement(cache, sql, timeout)
     end
   end
 
-  defp prepare_new_statement(%__MODULE__{db: db} = cache, sql) do
-    case Sqlitex.Statement.prepare(db, sql) do
+  defp prepare_new_statement(%__MODULE__{db: db} = cache, sql, timeout) do
+    case Sqlitex.Statement.prepare(db, sql, timeout) do
       {:ok, prepared} ->
         cache = cache
           |> store_new_stmt(sql, prepared)

--- a/lib/sqlitex/server/statement_cache.ex
+++ b/lib/sqlitex/server/statement_cache.ex
@@ -25,17 +25,17 @@ defmodule Sqlitex.Server.StatementCache do
 
   Will return `{:error, reason}` if SQLite is unable to prepare the statement.
   """
-  def prepare(%__MODULE__{cached_stmts: cached_stmts} = cache, sql, timeout)
+  def prepare(%__MODULE__{cached_stmts: cached_stmts} = cache, sql, opts \\ [])
     when is_binary(sql) and byte_size(sql) > 0
   do
     case Map.fetch(cached_stmts, sql) do
       {:ok, stmt} -> {update_cache_for_read(cache, sql), stmt}
-      :error -> prepare_new_statement(cache, sql, timeout)
+      :error -> prepare_new_statement(cache, sql, opts)
     end
   end
 
-  defp prepare_new_statement(%__MODULE__{db: db} = cache, sql, timeout) do
-    case Sqlitex.Statement.prepare(db, sql, timeout) do
+  defp prepare_new_statement(%__MODULE__{db: db} = cache, sql, opts \\ []) do
+    case Sqlitex.Statement.prepare(db, sql, opts) do
       {:ok, prepared} ->
         cache = cache
           |> store_new_stmt(sql, prepared)

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -73,6 +73,8 @@ defmodule Sqlitex.Statement do
             column_names: [],
             column_types: []
 
+  @esqlite3_timeout Application.get_env(:sqlitex, :esqlite3_timeout, 5_000)
+
   @doc """
   Prepare a Sqlitex.Statement
 
@@ -80,27 +82,28 @@ defmodule Sqlitex.Statement do
 
   * `db` - The database to prepare the statement for.
   * `sql` - The SQL of the statement to prepare.
+  * `timeout` - The time in ms allowed for the statement to run. Defaults to 5000, or the :esqlite3_timeout value in Application env.
 
   ## Returns
 
   * `{:ok, statement}` on success
   * See `:esqlite3.prepare` for errors.
   """
-  def prepare(db, sql) do
-    with {:ok, stmt} <- do_prepare(db, sql),
-         {:ok, stmt} <- get_column_names(stmt),
-         {:ok, stmt} <- get_column_types(stmt),
+  def prepare(db, sql, timeout \\ @esqlite3_timeout) do
+    with {:ok, stmt} <- do_prepare(db, sql, timeout),
+         {:ok, stmt} <- get_column_names(stmt, timeout),
+         {:ok, stmt} <- get_column_types(stmt, timeout),
          {:ok, stmt} <- extract_returning_clause(stmt, sql),
     do: {:ok, stmt}
   end
 
   @doc """
-  Same as `prepare/2` but raises a Sqlitex.Statement.PrepareError on error.
+  Same as `prepare/3` but raises a Sqlitex.Statement.PrepareError on error.
 
   Returns a new statement otherwise.
   """
-  def prepare!(db, sql) do
-    case prepare(db, sql) do
+  def prepare!(db, sql, timeout \\ @esqlite3_timeout) do
+    case prepare(db, sql, timeout) do
       {:ok, statement} -> statement
       {:error, reason} -> raise Sqlitex.Statement.PrepareError, reason: reason
     end
@@ -113,6 +116,7 @@ defmodule Sqlitex.Statement do
 
   * `statement` - The statement to bind values into.
   * `values` - A list of values to bind into the statement.
+  * `timeout` - The time in ms allowed for the statement to run. Defaults to 5000, or the :esqlite3_timeout value in Application env.
 
   ## Returns
 
@@ -129,20 +133,20 @@ defmodule Sqlitex.Statement do
   * `datetime` - Converted into a string.  See datetime_to_string
   * `%Decimal` -  Converted into a number.
   """
-  def bind_values(statement, values) do
-    case :esqlite3.bind(statement.statement, translate_bindings(values)) do
+  def bind_values(statement, values, timeout \\ @esqlite3_timeout) do
+    case :esqlite3.bind(statement.statement, translate_bindings(values), timeout) do
       {:error, _} = error -> error
       :ok -> {:ok, statement}
     end
   end
 
   @doc """
-  Same as `bind_values/2` but raises a Sqlitex.Statement.BindValuesError on error.
+  Same as `bind_values/3` but raises a Sqlitex.Statement.BindValuesError on error.
 
   Returns the statement otherwise.
   """
-  def bind_values!(statement, values) do
-    case bind_values(statement, values) do
+  def bind_values!(statement, values, timeout \\ @esqlite3_timeout) do
+    case bind_values(statement, values, timeout) do
       {:ok, statement} -> statement
       {:error, reason} -> raise Sqlitex.Statement.BindValuesError, reason: reason
     end
@@ -198,14 +202,15 @@ defmodule Sqlitex.Statement do
   ## Parameters
 
   * `statement` - The statement to run.
+  * `timeout` - The time in ms allowed for the statement to run. Defaults to 5000, or the :esqlite3_timeout value in Application env.
 
   ## Returns
 
   * `:ok`
   * `{:error, error}`
   """
-  def exec(statement) do
-    case :esqlite3.step(statement.statement) do
+  def exec(statement, timeout \\ @esqlite3_timeout) do
+    case :esqlite3.step(statement.statement, timeout) do
       # esqlite3.step returns some odd values, so lets translate them:
       :"$done" -> :ok
       :"$busy" -> {:error, {:busy, "Sqlite database is busy"}}
@@ -214,37 +219,37 @@ defmodule Sqlitex.Statement do
   end
 
   @doc """
-  Same as `exec/1` but raises a Sqlitex.Statement.ExecError on error.
+  Same as `exec/2` but raises a Sqlitex.Statement.ExecError on error.
 
   Returns :ok otherwise.
   """
-  def exec!(statement) do
-    case exec(statement) do
+  def exec!(statement, timeout \\ @esqlite3_timeout) do
+    case exec(statement, timeout) do
       :ok -> :ok
       {:error, reason} -> raise Sqlitex.Statement.ExecError, reason: reason
     end
   end
 
-  defp do_prepare(db, sql) do
-    case :esqlite3.prepare(sql, db) do
+  defp do_prepare(db, sql, timeout) do
+    case :esqlite3.prepare(sql, db, timeout) do
       {:ok, statement} ->
         {:ok, %Sqlitex.Statement{database: db, statement: statement}}
       other -> other
     end
   end
 
-  defp get_column_names(%Sqlitex.Statement{statement: sqlite_statement} = statement) do
+  defp get_column_names(%Sqlitex.Statement{statement: sqlite_statement} = statement, timeout) do
     names =
       sqlite_statement
-      |> :esqlite3.column_names
+      |> :esqlite3.column_names(timeout)
       |> Tuple.to_list
     {:ok, %Sqlitex.Statement{statement | column_names: names}}
   end
 
-  defp get_column_types(%Sqlitex.Statement{statement: sqlite_statement} = statement) do
+  defp get_column_types(%Sqlitex.Statement{statement: sqlite_statement} = statement, timeout) do
     types =
       sqlite_statement
-      |> :esqlite3.column_types
+      |> :esqlite3.column_types(timeout)
       |> Tuple.to_list
     {:ok, %Sqlitex.Statement{statement | column_types: types}}
   end

--- a/test/server/statement_cache_test.exs
+++ b/test/server/statement_cache_test.exs
@@ -10,22 +10,22 @@ defmodule Sqlitex.Server.StatementCacheTest do
     cache = S.new(db, 3)
     assert %S{cached_stmts: %{}, db: _, limit: 3, lru: [], size: 0} = cache
 
-    {cache, stmt1a} = S.prepare(cache, "SELECT 42")
+    {cache, stmt1a} = S.prepare(cache, "SELECT 42", 5_000)
     assert %Stmt{column_names: [:"42"], column_types: [nil]} = stmt1a
 
-    {cache, stmt2a} = S.prepare(cache, "SELECT 43")
+    {cache, stmt2a} = S.prepare(cache, "SELECT 43", 5_000)
     assert %Stmt{column_names: [:"43"], column_types: [nil]} = stmt2a
 
-    {cache, stmt3} = S.prepare(cache, "SELECT 44")
+    {cache, stmt3} = S.prepare(cache, "SELECT 44", 5_000)
     assert %Stmt{column_names: [:"44"], column_types: [nil]} = stmt3
 
-    {cache, stmt1b} = S.prepare(cache, "SELECT 42")
+    {cache, stmt1b} = S.prepare(cache, "SELECT 42", 5_000)
     assert stmt1a == stmt1b # shouldn't have been purged
 
-    {cache, stmt4} = S.prepare(cache, "SELECT 353")
+    {cache, stmt4} = S.prepare(cache, "SELECT 353", 5_000)
     assert %Stmt{column_names: [:"353"], column_types: [nil]} = stmt4
 
-    {_cache, stmt2b} = S.prepare(cache, "SELECT 42")
+    {_cache, stmt2b} = S.prepare(cache, "SELECT 42", 5_000)
     refute stmt2a == stmt2b # should have been purged
   end
 
@@ -34,6 +34,6 @@ defmodule Sqlitex.Server.StatementCacheTest do
     cache = S.new(db, 3)
 
     assert {:error, {:sqlite_error, 'near "bogus": syntax error'}}
-      = S.prepare(cache, "bogus")
+      = S.prepare(cache, "bogus", 5_000)
   end
 end

--- a/test/server/statement_cache_test.exs
+++ b/test/server/statement_cache_test.exs
@@ -10,22 +10,22 @@ defmodule Sqlitex.Server.StatementCacheTest do
     cache = S.new(db, 3)
     assert %S{cached_stmts: %{}, db: _, limit: 3, lru: [], size: 0} = cache
 
-    {cache, stmt1a} = S.prepare(cache, "SELECT 42", 5_000)
+    {cache, stmt1a} = S.prepare(cache, "SELECT 42", [db_timeout: 5_000])
     assert %Stmt{column_names: [:"42"], column_types: [nil]} = stmt1a
 
-    {cache, stmt2a} = S.prepare(cache, "SELECT 43", 5_000)
+    {cache, stmt2a} = S.prepare(cache, "SELECT 43", [db_timeout: 5_000])
     assert %Stmt{column_names: [:"43"], column_types: [nil]} = stmt2a
 
-    {cache, stmt3} = S.prepare(cache, "SELECT 44", 5_000)
+    {cache, stmt3} = S.prepare(cache, "SELECT 44", [db_timeout: 5_000])
     assert %Stmt{column_names: [:"44"], column_types: [nil]} = stmt3
 
-    {cache, stmt1b} = S.prepare(cache, "SELECT 42", 5_000)
+    {cache, stmt1b} = S.prepare(cache, "SELECT 42", [db_timeout: 5_000])
     assert stmt1a == stmt1b # shouldn't have been purged
 
-    {cache, stmt4} = S.prepare(cache, "SELECT 353", 5_000)
+    {cache, stmt4} = S.prepare(cache, "SELECT 353", [db_timeout: 5_000])
     assert %Stmt{column_names: [:"353"], column_types: [nil]} = stmt4
 
-    {_cache, stmt2b} = S.prepare(cache, "SELECT 42", 5_000)
+    {_cache, stmt2b} = S.prepare(cache, "SELECT 42", [db_timeout: 5_000])
     refute stmt2a == stmt2b # should have been purged
   end
 
@@ -34,6 +34,6 @@ defmodule Sqlitex.Server.StatementCacheTest do
     cache = S.new(db, 3)
 
     assert {:error, {:sqlite_error, 'near "bogus": syntax error'}}
-      = S.prepare(cache, "bogus", 5_000)
+      = S.prepare(cache, "bogus", [db_timeout: 5_000])
   end
 end


### PR DESCRIPTION
Hello.

First, thank you for the library. It's come in very useful for us.

We've been doing some work where we needed to increase the timeout `esqlite` applies to various operations. This pull request updates Sqlitex to expose the timeout argument in the various places that `esqlite` does so.

With these changes, Sqlitex defaults to the `esqlite` timeout of 5000 ms, and uses a combination of default values on the function arguments and implementing an `Application`-level config to leave the interface of Sqlitex unchanged for those who don't need to modify the timeout.

I think this is a broadly useful enough change to consider bringing into the upstream, but I worry that the implementation is a little noisy. Please let me know any changes you want made.

Thanks again.