### PR TITLE
Fix dialyzer errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: elixir
 otp_release:
- - 20.1
- - 20.2
  - 20.3
 elixir:
- - 1.4.5
- - 1.5.3
- - 1.6.4
+ - 1.4
+ - 1.5
+ - 1.6
+cache:
+  directories:
+  - /home/travis/.mix
+before_script:
+ - mix dialyzer --plt
+script:
+ - mix test
+ - mix dialyzer --halt-exit-status --no-check
 after_script:
   - MIX_ENV=dev mix deps.get
   - MIX_ENV=dev mix inch.report

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ elixir:
 cache:
   directories:
   - /home/travis/.mix
+  - /home/travis/build/mmmries/sqlitex/deps
+  - /home/travis/build/mmmries/sqlitex/_build
 before_script:
  - mix dialyzer --plt
 script:

--- a/lib/sqlitex/row.ex
+++ b/lib/sqlitex/row.ex
@@ -55,7 +55,7 @@ defmodule Sqlitex.Row do
   defp translate_value({float, "decimal(" <> rest}) do
     [precision, scale] = rest |> string_rstrip(?)) |> String.split(",") |> Enum.map(&String.to_integer/1)
     Decimal.with_context %Decimal.Context{precision: precision, rounding: :down}, fn ->
-      float |> Float.round(scale) |> Decimal.new |> Decimal.plus
+      float |> Float.round(scale) |> Float.to_string |> Decimal.new |> Decimal.plus
     end
   end
 

--- a/lib/sqlitex/server/statement_cache.ex
+++ b/lib/sqlitex/server/statement_cache.ex
@@ -34,7 +34,7 @@ defmodule Sqlitex.Server.StatementCache do
     end
   end
 
-  defp prepare_new_statement(%__MODULE__{db: db} = cache, sql, opts \\ []) do
+  defp prepare_new_statement(%__MODULE__{db: db} = cache, sql, opts) do
     case Sqlitex.Statement.prepare(db, sql, opts) do
       {:ok, prepared} ->
         cache = cache

--- a/mix.exs
+++ b/mix.exs
@@ -2,20 +2,23 @@ defmodule Sqlitex.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :sqlitex,
-     version: "1.4.0",
-     elixir: "~> 1.2",
-     deps: deps(),
-     package: package(),
-     test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: [
-        "coveralls": :test,
-        "coveralls.detail": :test,
-        "coveralls.post": :test,
-        "coveralls.html": :test],
-     description: """
-      A thin Elixir wrapper around esqlite
-    """]
+    [
+      app: :sqlitex,
+      version: "1.4.0",
+      elixir: "~> 1.2",
+      deps: deps(),
+      package: package(),
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+         "coveralls": :test,
+         "coveralls.detail": :test,
+         "coveralls.post": :test,
+         "coveralls.html": :test],
+      description: """
+        A thin Elixir wrapper around esqlite
+      """,
+      dialyzer: [plt_add_deps: :transitive],
+    ]
   end
 
   # Configuration for the OTP application
@@ -26,7 +29,7 @@ defmodule Sqlitex.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:esqlite, "~> 0.2.3"},
+      {:esqlite, "~> 0.2.4"},
       {:decimal, "~> 1.1"},
 
       {:credo, "~> 0.4", only: :dev},

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -193,7 +193,7 @@ defmodule SqlitexTest do
   test "decimal types" do
     {:ok, db} = Sqlitex.open(":memory:")
     :ok = Sqlitex.exec(db, "CREATE TABLE t (f DECIMAL)")
-    d = Decimal.new(1.123)
+    d = Decimal.new("1.123")
     {:ok, []} = Sqlitex.query(db, "INSERT INTO t VALUES (?)", bind: [d])
     {:ok, [row]} = Sqlitex.query(db, "SELECT f FROM t")
     assert row[:f] == d
@@ -202,14 +202,14 @@ defmodule SqlitexTest do
   test "decimal types with scale and precision" do
     {:ok, db} = Sqlitex.open(":memory:")
     :ok = Sqlitex.exec(db, "CREATE TABLE t (id INTEGER, f DECIMAL(3,2))")
-    {:ok, []} = Sqlitex.query(db, "INSERT INTO t VALUES (?,?)", bind: [1, Decimal.new(1.123)])
-    {:ok, []} = Sqlitex.query(db, "INSERT INTO t VALUES (?,?)", bind: [2, Decimal.new(244.37)])
-    {:ok, []} = Sqlitex.query(db, "INSERT INTO t VALUES (?,?)", bind: [3, Decimal.new(1997)])
+    {:ok, []} = Sqlitex.query(db, "INSERT INTO t VALUES (?,?)", bind: [1, Decimal.new("1.123")])
+    {:ok, []} = Sqlitex.query(db, "INSERT INTO t VALUES (?,?)", bind: [2, Decimal.new("244.37")])
+    {:ok, []} = Sqlitex.query(db, "INSERT INTO t VALUES (?,?)", bind: [3, Decimal.new("1997")])
 
     # results should be truncated to the appropriate precision and scale:
     Sqlitex.query!(db, "SELECT f FROM t ORDER BY id")
     |> Enum.map(fn row -> row[:f] end)
-    |> Enum.zip([Decimal.new(1.12), Decimal.new(244), Decimal.new(1990)])
+    |> Enum.zip([Decimal.new("1.12"), Decimal.new(244), Decimal.new(1990)])
     |> Enum.each(fn {res, ans} -> assert Decimal.equal?(res, ans) end)
   end
 


### PR DESCRIPTION
I noticed the other day that we had a couple of dialyzer errors in the project. I would like to minimize these in the future so I thought that running dialyzer during CI would be nice. In order to make this run relatively quickly I've added caching of the `/home/travis/.mix` directory which means that Travis should cache the PLT file for erlang/elixir libraries and then we just re-build the PLTs for our deps and our project on each build.

__Dialyzer Errors__

The first error was that when calling `esqlite3.q/2` we were passing the query as a binary, but the function was spec'd as expecting an `iolist()`. I actually [fixed this](https://github.com/mmzeeman/esqlite/pull/37) in esqlite a long time ago, but it looks like that change was missed in the `0.2.3` release. So I pulled the master branch which included my change and all other recent changes to made a `0.2.4` release to hex.pm.

The other error was when calling `Decimal.new/1`.  According to [the Decimal docs](https://hexdocs.pm/decimal/1.5.0/Decimal.html#new/1) `Decimal.new/1` expects an integer or a string. It appears to work fine with a float, but I changed our tests and implementation code to pass a string.