### PR TITLE
fix decimal scale and precision parsing

### DIFF
--- a/lib/sqlitex/row.ex
+++ b/lib/sqlitex/row.ex
@@ -53,7 +53,7 @@ defmodule Sqlitex.Row do
   end
   defp translate_value({float, "decimal"}), do: Decimal.new(float)
   defp translate_value({float, "decimal(" <> rest}) do
-    [precision, scale] = rest |> string_rstrip(?)) |> String.split(",") |> Enum.map(&String.to_integer/1)
+    [precision, scale] = rest |> string_rstrip(?)) |> String.split(",") |> Enum.map(&(&1 |> String.trim() |> String.to_integer))
     Decimal.with_context %Decimal.Context{precision: precision, rounding: :down}, fn ->
       float |> Float.round(scale) |> Float.to_string |> Decimal.new |> Decimal.plus
     end

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -213,6 +213,14 @@ defmodule SqlitexTest do
     |> Enum.each(fn {res, ans} -> assert Decimal.equal?(res, ans) end)
   end
 
+  test "decimal types with spaces near scale and precision" do
+    {:ok, db} = Sqlitex.open(":memory:")
+    :ok = Sqlitex.exec(db, "CREATE TABLE t (f1 DECIMAL(3,2), f2 DECIMAL(3, 2), f3 DECIMAL( 3 ,2 ))")
+    {:ok, []} = Sqlitex.query(db, "INSERT INTO t VALUES (?,?,?)", bind: [Decimal.new("1.23"), Decimal.new("4.56"), Decimal.new("7.89")])
+    [row] = Sqlitex.query!(db, "SELECT f1, f2, f3 FROM t")
+    assert row == [f1: Decimal.new("1.23"), f2: Decimal.new("4.56"), f3: Decimal.new("7.89")]
+  end
+
   test "it handles datetime, date, time with empty string" do
     {:ok, db} = Sqlitex.open(":memory:")
     :ok = Sqlitex.exec(db, "CREATE TABLE t (a datetime NOT NULL, b date NOT NULL, c time NOT NULL)")


### PR DESCRIPTION
I created table `price_list` with field `price DECIMAL(34, 10)`. And when I try to select data from this table, I get error. Then I create same table and field without space between precision and scale -  query working.
```
** (exit) exited in: GenServer.call(Sqlitex.Server, {:query, "select * from price_list ORDER BY company_id limit 1", []}, 5000)
    ** (EXIT) an exception was raised:
        ** (ArgumentError) argument error
            :erlang.binary_to_integer(" 10")
            (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
            (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
            (sqlitex) lib/sqlitex/row.ex:58: Sqlitex.Row.translate_value/1
            (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
            (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
            (sqlitex) lib/sqlitex/row.ex:16: Sqlitex.Row.build_row/4
            (sqlitex) lib/sqlitex/row.ex:5: anonymous fn/5 in Sqlitex.Row.from/4
    (elixir) lib/gen_server.ex:836: GenServer.call/3
```